### PR TITLE
ForRangeLoop now checks loop var < end, not end != 0

### DIFF
--- a/tests/test_for_loops.py
+++ b/tests/test_for_loops.py
@@ -39,9 +39,7 @@ def test_for_range(
     builder = builder_class()
 
     # `for` statement
-    var_a = astx.InlineVariableDeclaration(
-        "a", type_=int_type(), value=literal_type(-1)
-    )
+    var_a = astx.InlineVariableDeclaration("a", type_=int_type())
     start = literal_type(1)
     end = literal_type(10)
     step = literal_type(1)
@@ -67,8 +65,7 @@ def test_for_range(
     module = builder.module()
     module.block.append(fn_main)
 
-    # note: this test is not working actually, maybe it has an infinite loop
-    # check_result(action, builder, module, expected_file)
+    check_result(action, builder, module, expected_file)
 
 
 @pytest.mark.parametrize(
@@ -126,5 +123,4 @@ def test_for_count(
     module = builder.module()
     module.block.append(fn_main)
 
-    # note: not yet fully implemented
     check_result(action, builder, module, expected_file)


### PR DESCRIPTION
## Pull Request description
The loop condition was previously checking whether the end value was non-zero, which doesn't depend on the loop variable and leads to incorrect behavior.
Now, the condition correctly compares the loop variable (cur_var) with the end value (end_cond), using < or > based on the sign of the step value.

<!-- Describe the purpose of your PR and the changes you have made. -->

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solve #4
-->#59 

## How to test these changes
 run `pytest`
<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

- `...`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->
<img width="1470" alt="Screenshot 2025-04-17 at 11 05 02 PM" src="https://github.com/user-attachments/assets/1b207a4e-9f90-4c82-91d5-79452952d743" />

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
