### PR TITLE
Fix incorrect result handling in Block visitor

### DIFF
--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -404,15 +404,16 @@ class LLVMLiteIRVisitor(BuilderVisitor):
     @dispatch  # type: ignore[no-redef]
     def visit(self, block: astx.Block) -> None:
         """Translate ASTx Block to LLVM-IR."""
-        result = []
+        result = None
         for node in block.nodes:
             self.visit(node)
             try:
-                result.append(self.result_stack.pop())
+                result = self.result_stack.pop()
             except IndexError:
                 # some nodes doesn't add anything in the stack
                 pass
-        self.result_stack.append(result)
+        if result is not None:
+            self.result_stack.append(result)
 
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.IfStmt) -> None:


### PR DESCRIPTION
## Pull Request description
Replaced the list accumulation approach with logic that only pushes the result of the last expression in the block. This aligns block behavior with typical C/Python-style semantics, where a block doesn't return a value unless explicitly required .The previous behavior caused type errors and runtime crashes during IR generation, especially in control-flow constructs like `ifStmt`. 


<!-- Describe the purpose of your PR and the changes you have made. -->

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solve #4
-->

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

- `...`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
