### PR TITLE
resest the names_values in LLVMLiteIRVisitor

### DIFF
--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -881,7 +881,8 @@ class LLVMLiteIR(Builder):
 
     def build(self, node: astx.AST, output_file: str) -> None:
         """Transpile the ASTx to LLVM-IR and build it to an executable file."""
-        result = self.translate(node)
+        self.translator = LLVMLiteIRVisitor()
+        result = self.translator.translate(node)
 
         result_mod = llvm.parse_assembly(result)
         result_object = self.translator.target_machine.emit_object(result_mod)


### PR DESCRIPTION
## Pull Request description
LLVMLiteIR.build() must reset the translator before using it, current implementation only runs once in __init__ and we are reusing the same stateful visitor across tests.

<!-- Describe the purpose of your PR and the changes you have made. -->

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solve #4
-->

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

- `...`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->
<img width="1470" alt="Screenshot 2025-04-23 at 9 49 25 PM" src="https://github.com/user-attachments/assets/85008d38-fb5a-41dd-8fef-a02c05121762" />

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
