### PR TITLE
chore(ci): Add support fo MacOS on CI with azurepipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-# Azure Pipeline for macOS testing
+# Azure Pipeline for macOS CI tests
 trigger:
   branches:
     include:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,77 @@
+# Azure Pipeline for macOS testing
+trigger:
+  branches:
+    include:
+    - main
+  
+pr:
+  branches:
+    include:
+    - main
+
+jobs:
+- job: macOS_tests
+  displayName: macOS Tests
+  timeoutInMinutes: 10
+  pool:
+    vmImage: 'macOS-latest'
+  strategy:
+    matrix:
+      Python39:
+        python_version: '3.9'
+      Python310:
+        python_version: '3.10'
+      Python311:
+        python_version: '3.11'
+      Python312:
+        python_version: '3.12'
+  
+  steps:
+  - checkout: self
+  
+  - script: |
+      brew install llvm@14
+      brew link --force llvm@14
+      export LLVM_CONFIG=$(brew --prefix llvm@14)/bin/llvm-config
+      echo "##vso[task.setvariable variable=LLVM_CONFIG]$(brew --prefix llvm@14)/bin/llvm-config"
+    displayName: 'Install LLVM'
+  
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: $(python_version)
+      addToPath: true
+    displayName: 'Setup Python $(python_version)'
+  
+  - script: |
+      curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh
+      bash miniconda.sh -b -p $HOME/miniconda
+      source $HOME/miniconda/bin/activate
+      conda config --set always_yes yes --set changeps1 no
+      conda config --add channels conda-forge
+      conda config --set channel_priority strict
+      conda install -y mamba
+      mamba env create -f conda/ci.yaml
+      source activate irx
+    displayName: 'Setup conda environment'
+  
+  - script: |
+      source $HOME/miniconda/bin/activate irx
+      export LLVM_CONFIG=$(brew --prefix llvm@14)/bin/llvm-config
+      poetry check
+      poetry install
+    displayName: 'Install dependencies'
+  
+  - script: |
+      source $HOME/miniconda/bin/activate irx
+      export LLVM_CONFIG=$(brew --prefix llvm@14)/bin/llvm-config
+      poetry run makim tests.unit
+    displayName: 'Run tests'
+    
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: '**/test-*.xml'
+      testRunTitle: 'macOS Python $(python_version) Tests'
+    displayName: 'Publish test results'
+    

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,76 +2,75 @@
 trigger:
   branches:
     include:
-    - main
-  
+      - main
+
 pr:
   branches:
     include:
-    - main
+      - main
 
 jobs:
-- job: macOS_tests
-  displayName: macOS Tests
-  timeoutInMinutes: 10
-  pool:
-    vmImage: 'macOS-latest'
-  strategy:
-    matrix:
-      Python39:
-        python_version: '3.9'
-      Python310:
-        python_version: '3.10'
-      Python311:
-        python_version: '3.11'
-      Python312:
-        python_version: '3.12'
-  
-  steps:
-  - checkout: self
-  
-  - script: |
-      brew install llvm@14
-      brew link --force llvm@14
-      export LLVM_CONFIG=$(brew --prefix llvm@14)/bin/llvm-config
-      echo "##vso[task.setvariable variable=LLVM_CONFIG]$(brew --prefix llvm@14)/bin/llvm-config"
-    displayName: 'Install LLVM'
-  
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: $(python_version)
-      addToPath: true
-    displayName: 'Setup Python $(python_version)'
-  
-  - script: |
-      curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh
-      bash miniconda.sh -b -p $HOME/miniconda
-      source $HOME/miniconda/bin/activate
-      conda config --set always_yes yes --set changeps1 no
-      conda config --add channels conda-forge
-      conda config --set channel_priority strict
-      conda install -y mamba
-      mamba env create -f conda/ci.yaml
-      source activate irx
-    displayName: 'Setup conda environment'
-  
-  - script: |
-      source $HOME/miniconda/bin/activate irx
-      export LLVM_CONFIG=$(brew --prefix llvm@14)/bin/llvm-config
-      poetry check
-      poetry install
-    displayName: 'Install dependencies'
-  
-  - script: |
-      source $HOME/miniconda/bin/activate irx
-      export LLVM_CONFIG=$(brew --prefix llvm@14)/bin/llvm-config
-      poetry run makim tests.unit
-    displayName: 'Run tests'
-    
-  - task: PublishTestResults@2
-    condition: succeededOrFailed()
-    inputs:
-      testResultsFormat: 'JUnit'
-      testResultsFiles: '**/test-*.xml'
-      testRunTitle: 'macOS Python $(python_version) Tests'
-    displayName: 'Publish test results'
-    
+  - job: macOS_tests
+    displayName: macOS Tests
+    timeoutInMinutes: 10
+    pool:
+      vmImage: "macOS-latest"
+    strategy:
+      matrix:
+        Python39:
+          python_version: "3.9"
+        Python310:
+          python_version: "3.10"
+        Python311:
+          python_version: "3.11"
+        Python312:
+          python_version: "3.12"
+
+    steps:
+      - checkout: self
+
+      - script: |
+          brew install llvm@14
+          brew link --force llvm@14
+          export LLVM_CONFIG=$(brew --prefix llvm@14)/bin/llvm-config
+          echo "##vso[task.setvariable variable=LLVM_CONFIG]$(brew --prefix llvm@14)/bin/llvm-config"
+        displayName: "Install LLVM"
+
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(python_version)
+          addToPath: true
+        displayName: "Setup Python $(python_version)"
+
+      - script: |
+          curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh
+          bash miniconda.sh -b -p $HOME/miniconda
+          source $HOME/miniconda/bin/activate
+          conda config --set always_yes yes --set changeps1 no
+          conda config --add channels conda-forge
+          conda config --set channel_priority strict
+          conda install -y mamba
+          mamba env create -f conda/ci.yaml
+          source activate irx
+        displayName: "Setup conda environment"
+
+      - script: |
+          source $HOME/miniconda/bin/activate irx
+          export LLVM_CONFIG=$(brew --prefix llvm@14)/bin/llvm-config
+          poetry check
+          poetry install
+        displayName: "Install dependencies"
+
+      - script: |
+          source $HOME/miniconda/bin/activate irx
+          export LLVM_CONFIG=$(brew --prefix llvm@14)/bin/llvm-config
+          poetry run makim tests.unit
+        displayName: "Run tests"
+
+      - task: PublishTestResults@2
+        condition: succeededOrFailed()
+        inputs:
+          testResultsFormat: "JUnit"
+          testResultsFiles: "**/test-*.xml"
+          testRunTitle: "macOS Python $(python_version) Tests"
+        displayName: "Publish test results"

--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -1005,7 +1005,7 @@ class LLVMLiteIR(Builder):
 
         self.output_file = output_file
 
-        xh.clang(  # type: ignore
+        xh.clang(
             file_path_o,
             "-o",
             self.output_file,


### PR DESCRIPTION
## Pull Request description

Add Azure Pipelines for macOS testing since macOS support was dropped from GitHub Actions in PR #57 due to issues with the ld linker. 

This PR follows the approach used by llvmlite and numba projects, which use Azure Pipelines for macOS testing.

Resolves #58 

**This PR also fixes an issue with an unused `# type: ignore` comment in the `src/irx/builders/llvmliteir.py` file that was causing linting errors.**

## How to test these changes

- Connect the repository to Azure DevOps
- Create a new pipeline pointing to the azure-pipelines.yml file
- Run the pipeline to verify macOS tests pass

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [x] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [x] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

This configuration follows the pattern used by:
- llvmlite: https://github.com/numba/llvmlite/blob/main/azure-pipelines.yml
- numba: https://github.com/numba/numba/blob/main/azure-pipelines.yml

By moving macOS testing to Azure Pipelines, we can avoid the ld linker issues encountered in GitHub Actions while still ensuring our code works on macOS.

## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
