### PR TITLE
Add int↔float promotion support in LLVM IR operand handling

### DIFF
--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -233,6 +233,16 @@ class LLVMLiteIRVisitor(BuilderVisitor):
         self._llvm.ir_builder.position_at_end(self._llvm.ir_builder.block)
         return alloca
 
+    def fp_rank(self, t: ir.Type) -> int:
+        """Rank floating-point types: half < float < double."""
+        if isinstance(t, ir.HalfType):
+            return 1
+        if isinstance(t, ir.FloatType):
+            return 2
+        if isinstance(t, ir.DoubleType):
+            return 3
+        return 0
+
     def promote_operands(
         self, lhs: ir.Value, rhs: ir.Value
     ) -> tuple[ir.Value, ir.Value]:
@@ -264,33 +274,25 @@ class LLVMLiteIRVisitor(BuilderVisitor):
                 rhs = self._llvm.ir_builder.sext(rhs, lhs.type, "promote_rhs")
             return lhs, rhs
 
-        def fp_rank(t: ir.Type) -> int:
-            # ranks: half < float < double
-            s = str(t)
-            if "half" in s or isinstance(t, ir.HalfType):
-                return 1
-            if "float" in s and "double" not in s:
-                return 2
-            if "double" in s or isinstance(t, ir.DoubleType):
-                return 3
-            return 0
+        lhs_fp_rank = self.fp_rank(lhs.type)
+        rhs_fp_rank = self.fp_rank(rhs.type)
 
-        if fp_rank(lhs.type) > 0 and fp_rank(rhs.type) > 0:
+        if lhs_fp_rank > 0 and rhs_fp_rank > 0:
             # make both the wider FP
-            if fp_rank(lhs.type) < fp_rank(rhs.type):
+            if lhs_fp_rank < rhs_fp_rank:
                 lhs = self._llvm.ir_builder.fpext(lhs, rhs.type, "promote_lhs")
-            elif fp_rank(lhs.type) > fp_rank(rhs.type):
+            elif lhs_fp_rank > rhs_fp_rank:
                 rhs = self._llvm.ir_builder.fpext(rhs, lhs.type, "promote_rhs")
             return lhs, rhs
 
         # If one is int and other is FP, convert int -> FP (sitofp),
-        if isinstance(lhs.type, ir.IntType) and fp_rank(rhs.type) > 0:
+        if isinstance(lhs.type, ir.IntType) and rhs_fp_rank > 0:
             target_fp = rhs.type
             lhs_fp = self._llvm.ir_builder.sitofp(lhs, target_fp, "int_to_fp")
             # Now if rhs is narrower/wider, adjust (rhs already target_fp here)
             return lhs_fp, rhs
 
-        if isinstance(rhs.type, ir.IntType) and fp_rank(lhs.type) > 0:
+        if isinstance(rhs.type, ir.IntType) and lhs_fp_rank > 0:
             target_fp = lhs.type
             rhs_fp = self._llvm.ir_builder.sitofp(rhs, target_fp, "int_to_fp")
             return lhs, rhs_fp

--- a/tests/test_cast.py
+++ b/tests/test_cast.py
@@ -67,3 +67,51 @@ def test_cast_basic(
 
     expected_output = "42"
     check_result("build", builder, module, expected_output=expected_output)
+
+
+@pytest.mark.parametrize(
+    "builder_class",
+    [
+        LLVMLiteIR,
+    ],
+)
+def test_cast_int_to_float_and_back(builder_class: Type[Builder]) -> None:
+    """Test casting int -> float -> int, returning int result."""
+    builder = builder_class()
+    module = builder.module()
+
+    # a: i32 = 42
+    decl_a = astx.VariableDeclaration(
+        name="a", type_=astx.Int32(), value=astx.LiteralInt32(42)
+    )
+    a_ident = astx.Identifier("a")
+
+    # r: float32 = cast(a)        # int -> float->42.0
+    cast_to_float = Cast(value=a_ident, target_type=astx.Float32())
+    cast_var_float = astx.InlineVariableDeclaration(
+        name="r", type_=astx.Float32(), value=cast_to_float
+    )
+
+    # s: int32 = cast(r)          # float -> int
+    r_ident = astx.Identifier("r")
+    cast_back_to_int = Cast(value=r_ident, target_type=astx.Int32())
+    cast_var_int = astx.InlineVariableDeclaration(
+        name="s", type_=astx.Int32(), value=cast_back_to_int
+    )
+
+    # main returns int32
+    main_proto = astx.FunctionPrototype(
+        name="main", args=astx.Arguments(), return_type=astx.Int32()
+    )
+    main_block = astx.Block()
+    main_block.append(decl_a)
+    main_block.append(cast_var_float)
+    main_block.append(cast_var_int)
+    main_block.append(astx.FunctionReturn(astx.Identifier("s")))
+    main_fn = astx.FunctionDef(prototype=main_proto, body=main_block)
+
+    module.block.append(main_fn)
+
+    # expected output: program exit code "42"
+    expected_output = "42"
+    check_result("build", builder, module, expected_output=expected_output)


### PR DESCRIPTION
## Pull Request description

<!-- Describe the purpose of your PR and the changes you have made. -->
This PR enhances the promote_operands method to handle mixed-type arithmetic between integers and floating-point values.

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solve #4
-->#86

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

- `...`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
