### PR TITLE
Add LLVM VectorType and Vectorized Operations Support (#117)

### DIFF
--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -62,10 +62,10 @@ def splat_scalar(
     """Broadcast a scalar to all lanes of a vector."""
     zero_i32 = ir.Constant(ir.IntType(32), 0)
     undef_vec = ir.Constant(vec_type, ir.Undefined)
-    v0 = ir_builder.insertelement(undef_vec, scalar, zero_i32)
+    v0 = ir_builder.insert_element(undef_vec, scalar, zero_i32)
     mask_ty = ir.VectorType(ir.IntType(32), vec_type.count)
     mask = ir.Constant(mask_ty, [0] * vec_type.count)
-    return ir_builder.shufflevector(v0, undef_vec, mask)
+    return ir_builder.shuffle_vector(v0, undef_vec, mask)
 
 
 @typechecked

--- a/tests/test_llvmlite_helpers.py
+++ b/tests/test_llvmlite_helpers.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from irx.builders.llvmliteir import LLVMLiteIRVisitor
+from irx.builders.llvmliteir import (
+    LLVMLiteIRVisitor,
+    emit_int_div,
+    splat_scalar,
+)
 from llvmlite import ir
 
 
@@ -55,3 +59,39 @@ def test_emit_fma_fallback_intrinsic() -> None:
     assert inst.name == "vfma"
     assert "llvm.fma.f32" in proxy.called
     assert "llvm.fma.f32" in visitor._llvm.module.globals
+
+
+def test_splat_scalar_broadcasts_all_lanes() -> None:
+    """splat_scalar should broadcast the scalar into every lane."""
+    visitor = LLVMLiteIRVisitor()
+    _prime_builder(visitor)
+
+    float_ty = visitor._llvm.FLOAT_TYPE
+    scalar = ir.Constant(float_ty, 1.5)
+    vec_ty = ir.VectorType(float_ty, 4)
+
+    result = splat_scalar(visitor._llvm.ir_builder, scalar, vec_ty)
+
+    assert isinstance(result.type, ir.VectorType)
+    assert result.type == vec_ty
+    assert getattr(result, "opname", "") == "shufflevector"
+    mask = result.operands[2]
+    assert isinstance(mask, ir.Constant)
+    assert "i32 0, i32 0, i32 0, i32 0" in str(mask)
+
+
+def test_emit_int_div_signed_and_unsigned() -> None:
+    """emit_int_div should honour the unsigned flag."""
+    visitor = LLVMLiteIRVisitor()
+    _prime_builder(visitor)
+
+    builder = visitor._llvm.ir_builder
+    int_ty = ir.IntType(32)
+    lhs = ir.Constant(int_ty, 10)
+    rhs = ir.Constant(int_ty, 3)
+
+    signed = emit_int_div(builder, lhs, rhs, unsigned=False)
+    unsigned = emit_int_div(builder, lhs, rhs, unsigned=True)
+
+    assert getattr(signed, "opname", "") == "sdiv"
+    assert getattr(unsigned, "opname", "") == "udiv"


### PR DESCRIPTION
### Notes

- This repository uses an AI bot for reviews. Keep your PR in **Draft** while
  you work. When you’re ready for a review, change the status to **Ready for
  review** to trigger a new review round. If you make additional changes and
  don’t want to trigger the bot, switch the PR back to **Draft**.
- AI-bot comments may not always be accurate. Please review them critically and
  share your feedback; it helps us improve the tool.
- Avoid changing code that is unrelated to your proposal. Keep your PR as short
  as possible to increase the chances of a timely review. Large PRs may not be
  reviewed and may be closed.
- Don’t add unnecessary comments. Your code should be readable and
  self-documenting
  ([guidance](https://google.github.io/styleguide/cppguide.html#Comments)).
- Don’t change core features without prior discussion with the community. Use
  our Discord to discuss ideas, blockers, or issues
  (https://discord.gg/Nu4MdGj9jB).
- Do not include secrets (API keys, tokens, passwords), credentials, or
  sensitive data/PII in code, configs, logs, screenshots, or commit history. If
  something leaks, rotate the credentials immediately, invalidate the old key,
  and note it in the PR so maintainers can assist.
- Do not commit large binaries or generated artifacts. If large datasets are
  needed for tests, prefer small fixtures or programmatic downloads declared in
  makim.yaml (e.g., a task that fetches data at test time). If a large binary is
  unavoidable, discuss first and consider Git LFS.

## Pull Request description

This PR introduces support for LLVM-style vector types and vectorized arithmetic operations in the IR builder, as outlined in [issue #117](https://github.com/arxlang/irx/issues/117).

**Key changes:**
- Added a `VectorType` class for strongly-typed SIMD vectors (element type & size).
- Enhanced code generation to dispatch arithmetic (`+`, `-`, `*`, `/`) to vector instructions when both operands are vectors, including type and size checks.
- Exposed fused multiply-add (FMA) logic and fast-math flags for floating-point vectors via node attributes.
- Preserved all prior scalar-operation/type-promotion logic for compatibility.
- Lays the groundwork for future SIMD features and optimization opportunities.

> This PR does **not** yet include frontend/AST support for vector literals or direct vector-operation tests, but is fully non-breaking for existing functionality.

**Solve #117**

## How to test these changes

- Run the full test suite to confirm no regressions:
  ```bash
  /Users/omsherikar/miniforge3/envs/irx/bin/python -m pytest
  ```
- (In followup: add tests using vector literals/operations to confirm IR code generation, once frontend support for vectors is in place.)

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests. _(vector tests pending frontend literal support)_
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.

## Additional information

- This foundation enables future SIMD, FMA, and optimized math in IRX.
- Next steps: AST/frontend literal vector support and full vector operation test cases.

## Reviewer's checklist

Copy and paste this template for your review's note:
