### PR TITLE
fix: zero-extend i1 boolean for correct string printing

### DIFF
--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -1602,7 +1602,11 @@ class LLVMLiteIRVisitor(BuilderVisitor):
             raise Exception("Expected integer value")
         w = v.type.width
         if w < INT64_WIDTH:
-            arg = self._llvm.ir_builder.sext(v, self._llvm.INT64_TYPE)
+            # i1 uses zero-extension to print as 1/0, not -1/0
+            if w == 1:
+                arg = self._llvm.ir_builder.zext(v, self._llvm.INT64_TYPE)
+            else:
+                arg = self._llvm.ir_builder.sext(v, self._llvm.INT64_TYPE)
             return arg, "%lld"
         if w == INT64_WIDTH:
             return v, "%lld"


### PR DESCRIPTION
## Pull Request description

Fixed boolean string casting: `i1` (boolean) values now zero-extend instead of sign-extend when converting to strings for `printf`, so `true` prints as `1` instead of `-1`.

Issue: `_normalize_int_for_printf` sign-extended all sub-64-bit integers, including `i1`. With `sext`, `true` (1) became `-1` in `i64`, leading to `-1` output.

Solution: Special-case `i1` to use `zext`, keeping `true` as `1` while preserving sign-extension for other integer types.

Solves #119

## How to test these changes

- Run boolean tests:
  ```bash
  pytest tests/test_cast.py::test_cast_boolean_to_string -v
  ```
- Verify boolean values print `1` and `0`:
  ```bash
  pytest tests/test_cast.py -v
  ```
- Run full test suite:
  ```bash
  pytest -q
  ```

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

**Technical Details:**
- LLVM `sext` copies the MSB. For `i1`, `true` → `-1` in larger types.
- LLVM `zext` fills with zero, so `true` → `1`.
- `_normalize_int_for_printf` still uses `sext` for other integer types.

**Testing:**
- Added `test_cast_boolean_to_string` covering `true` and `false`.
- 100 tests pass locally, pre-commit passes.

## Reviewer's checklist

## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved
