### PR TITLE
fix: replace alloca with malloc in strcat to avoid use-after-return

### DIFF
--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -1405,8 +1405,10 @@ class LLVMLiteIRVisitor(BuilderVisitor):
             "total_len_with_null",
         )
 
-        # For simplicity, using alloca
-        result_ptr = builder.alloca(self._llvm.INT8_TYPE, total_len, "result")
+        # Allocate on heap to avoid use-after-return
+        malloc = self._create_malloc_decl()
+        total_len_szt = builder.zext(total_len, self._llvm.SIZE_T_TYPE)
+        result_ptr = builder.call(malloc, [total_len_szt], "result")
 
         self._generate_strcpy(builder, result_ptr, func.args[0])
 


### PR DESCRIPTION
## Pull Request description

This PR fixes a use-after-return bug in `_create_strcat_inline` where the function returned a pointer to stack-allocated memory (`alloca`), causing undefined behavior when the returned pointer was used after the function returned.

**Changes made:**
- Replaced `alloca` (stack allocation) with `malloc` (heap allocation) in `_create_strcat_inline()`
- Converted `total_len` from `i32` to `SIZE_T_TYPE` using `zext` to match `malloc` signature
- Follows the same pattern as `_snprintf_heap()` which already uses heap allocation correctly

**Why this fix:**
- `alloca` allocates memory on the function's stack frame
- When the function returns, the stack frame is deallocated
- Returning a pointer to stack memory causes use-after-return bugs
- Heap-allocated memory persists after function return, making it safe to return
Solves #129 

## How to test these changes

- Run the string concatenation tests:
  ```bash
  pytest tests/test_string.py::test_string_concatenation_with_print -v
  ```

- Run all string tests to ensure no regressions:
  ```bash
  pytest tests/test_string.py -v
  ```

- All 13 string tests should pass, including:
  - String concatenation with various inputs
  - String comparisons
  - Empty strings
  - Special characters

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests. (existing tests verify the fix)
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path). N/A
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.

## Additional information

**Code location:**
- File: `src/irx/builders/llvmliteir.py`
- Function: `_create_strcat_inline()` (lines 1408-1411)

**Before:**
```python
# For simplicity, using alloca
result_ptr = builder.alloca(self._llvm.INT8_TYPE, total_len, "result")
```

**After:**
```python
# Allocate on heap to avoid use-after-return
malloc = self._create_malloc_decl()
total_len_szt = builder.zext(total_len, self._llvm.SIZE_T_TYPE)
result_ptr = builder.call(malloc, [total_len_szt], "result")
```

**Test results:**
- ✅ All 13 string tests pass
- ✅ No regressions in existing functionality
- ✅ Fix follows established pattern from `_snprintf_heap()`

**Note:** Memory allocated with `malloc` is not freed, which matches the existing codebase pattern (similar to `_snprintf_heap`). This is acceptable for short-lived programs and test scenarios.

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```

