### PR TITLE
fix: Add missing `set_fast_math` method

### DIFF
--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -422,6 +422,13 @@ class LLVMLiteIRVisitor(BuilderVisitor):
         fma_fn = self._get_fma_function(lhs.type)
         return builder.call(fma_fn, [lhs, rhs, addend], name="vfma")
 
+    def set_fast_math(self, enable: bool) -> None:
+        """Enable or disable fast math flags on the IR builder."""
+        if enable:
+            self._llvm.ir_builder.set_fastmath_flags(["fast"])
+        else:
+            self._llvm.ir_builder.clear_fastmath_flags()
+
     @dispatch.abstract
     def visit(self, node: astx.AST) -> None:
         """Translate an ASTx expression."""


### PR DESCRIPTION
## Description: 

**Problem:**
llvmliteir.py calls `self.set_fast_math()` at lines 603, 608, 612, and 660, but the method doesn't exist, causing `AttributeError` at runtime for vector operations with fast math.

**Solution:**
Added `set_fast_math(enable: bool)` method that enables/disables fast math flags on the LLVM IR builder using llvmlite's `set_fastmath_flags(["fast"])` and `clear_fastmath_flags()` methods.

Closes #148 

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
