### PR TITLE
feat(ir): add LiteralTime support (#109)

### DIFF
--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -168,6 +168,8 @@ class VariablesLLVM:
         type: ir.types.Type
       UTF8_STRING_TYPE:
         type: ir.types.Type
+      TIME_TYPE:
+        type: ir.types.Type
       TIMESTAMP_TYPE:
         type: ir.types.Type
       DATETIME_TYPE:
@@ -196,6 +198,7 @@ class VariablesLLVM:
     STRING_TYPE: ir.types.Type
     ASCII_STRING_TYPE: ir.types.Type
     UTF8_STRING_TYPE: ir.types.Type
+    TIME_TYPE: ir.types.Type
     TIMESTAMP_TYPE: ir.types.Type
     DATETIME_TYPE: ir.types.Type
     SIZE_T_TYPE: ir.types.Type
@@ -387,6 +390,13 @@ class LLVMLiteIRVisitor(BuilderVisitor):
         self._llvm.ASCII_STRING_TYPE = ir.IntType(8).as_pointer()
         self._llvm.UTF8_STRING_TYPE = self._llvm.STRING_TYPE
         # Composite types
+        self._llvm.TIME_TYPE = ir.LiteralStructType(
+            [
+                self._llvm.INT32_TYPE,
+                self._llvm.INT32_TYPE,
+                self._llvm.INT32_TYPE,
+            ]
+        )
         self._llvm.TIMESTAMP_TYPE = ir.LiteralStructType(
             [
                 self._llvm.INT32_TYPE,
@@ -1710,6 +1720,81 @@ class LLVMLiteIRVisitor(BuilderVisitor):
         """
         utf8_literal = astx.LiteralUTF8String(value=expr.value)
         self.visit(utf8_literal)
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.LiteralTime) -> None:
+        """
+        title: Lower a LiteralTime to LLVM IR.
+        summary: >-
+          Representation: { i32 hour, i32 minute, i32 second } emitted as a
+          constant struct. Accepted formats are HH:MM and HH:MM:SS.
+        parameters:
+          node:
+            type: astx.LiteralTime
+        """
+        s = node.value.strip()
+
+        parts = s.split(":")
+        if len(parts) not in (2, 3):
+            raise Exception(
+                f"LiteralTime: invalid time format '{node.value}'. "
+                "Expected 'HH:MM' or 'HH:MM:SS'."
+            )
+
+        # Parse hour, minute
+        try:
+            hour = int(parts[0])
+            minute = int(parts[1])
+        except Exception as exc:
+            raise Exception(
+                f"LiteralTime: invalid hour/minute in '{node.value}'."
+            ) from exc
+
+        # Parse second (optional)
+        if len(parts) == 3:  # noqa: PLR2004
+            sec_part = parts[2]
+            if "." in sec_part:
+                raise Exception(
+                    "LiteralTime: fractional seconds "
+                    f"not supported in '{node.value}'."
+                )
+            try:
+                second = int(sec_part)
+            except Exception as exc:
+                raise Exception(
+                    f"LiteralTime: invalid seconds in '{node.value}'."
+                ) from exc
+        else:
+            second = 0
+
+        # Range checks
+        MAX_HOUR = 23
+        MAX_MINUTE = 59
+        MAX_SECOND = 59
+        if not (0 <= hour <= MAX_HOUR):
+            raise Exception(
+                f"LiteralTime: hour out of range in '{node.value}'."
+            )
+        if not (0 <= minute <= MAX_MINUTE):
+            raise Exception(
+                f"LiteralTime: minute out of range in '{node.value}'."
+            )
+        if not (0 <= second <= MAX_SECOND):
+            raise Exception(
+                f"LiteralTime: second out of range in '{node.value}'."
+            )
+
+        # Build constant struct { i32, i32, i32 }
+        i32 = self._llvm.INT32_TYPE
+        const_time = ir.Constant(
+            self._llvm.TIME_TYPE,
+            [
+                ir.Constant(i32, hour),
+                ir.Constant(i32, minute),
+                ir.Constant(i32, second),
+            ],
+        )
+        self.result_stack.append(const_time)
 
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.LiteralTimestamp) -> None:

--- a/tests/test_literal_time.py
+++ b/tests/test_literal_time.py
@@ -1,0 +1,151 @@
+"""
+title: Tests for LiteralTime lowering using project conventions.
+"""
+
+from __future__ import annotations
+
+import re
+
+from typing import Type, cast
+
+import astx
+import pytest
+
+from irx.builders.base import Builder
+from irx.builders.llvmliteir import LLVMLiteIR, LLVMLiteIRVisitor
+from llvmlite import ir
+
+HAS_LITERAL_TIME = hasattr(astx, "LiteralTime")
+
+
+def _time_values(const: ir.Constant) -> list[int]:
+    """
+    title: Extract i32 values from the literal struct constant.
+    parameters:
+      const:
+        type: ir.Constant
+    returns:
+      type: list[int]
+    """
+    return [int(v) for v in re.findall(r"i32\s+(-?\d+)", str(const))]
+
+
+@pytest.mark.skipif(
+    not HAS_LITERAL_TIME, reason="astx.LiteralTime not available"
+)
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_literal_time_hh_mm_ss(
+    builder_class: Type[Builder],
+) -> None:
+    """
+    title: HH:MM:SS time lowers to constant struct.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+    """
+    builder = builder_class()
+    visitor = cast(LLVMLiteIRVisitor, builder.translator)
+    visitor.result_stack.clear()
+
+    visitor.visit(astx.LiteralTime("12:34:56"))
+    const = visitor.result_stack.pop()
+
+    assert isinstance(const, ir.Constant)
+    assert const.type == visitor._llvm.TIME_TYPE
+    vals = _time_values(const)
+    assert vals == [12, 34, 56]
+    assert not visitor.result_stack
+
+
+@pytest.mark.skipif(
+    not HAS_LITERAL_TIME, reason="astx.LiteralTime not available"
+)
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_literal_time_hh_mm(
+    builder_class: Type[Builder],
+) -> None:
+    """
+    title: HH:MM time defaults second to zero.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+    """
+    builder = builder_class()
+    visitor = cast(LLVMLiteIRVisitor, builder.translator)
+    visitor.result_stack.clear()
+
+    visitor.visit(astx.LiteralTime("08:15"))
+    const = visitor.result_stack.pop()
+
+    assert isinstance(const, ir.Constant)
+    assert const.type == visitor._llvm.TIME_TYPE
+    vals = _time_values(const)
+    assert vals == [8, 15, 0]
+    assert not visitor.result_stack
+
+
+@pytest.mark.skipif(
+    not HAS_LITERAL_TIME, reason="astx.LiteralTime not available"
+)
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_literal_time_midnight(
+    builder_class: Type[Builder],
+) -> None:
+    """
+    title: Midnight 00:00:00 lowers correctly.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+    """
+    builder = builder_class()
+    visitor = cast(LLVMLiteIRVisitor, builder.translator)
+    visitor.result_stack.clear()
+
+    visitor.visit(astx.LiteralTime("00:00:00"))
+    const = visitor.result_stack.pop()
+
+    assert isinstance(const, ir.Constant)
+    assert const.type == visitor._llvm.TIME_TYPE
+    vals = _time_values(const)
+    assert vals == [0, 0, 0]
+    assert not visitor.result_stack
+
+
+@pytest.mark.skipif(
+    not HAS_LITERAL_TIME, reason="astx.LiteralTime not available"
+)
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_literal_time_hour_out_of_range(
+    builder_class: Type[Builder],
+) -> None:
+    """
+    title: Reject hour outside 0-23 range.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+    """
+    builder = builder_class()
+    visitor = cast(LLVMLiteIRVisitor, builder.translator)
+    visitor.result_stack.clear()
+    with pytest.raises(Exception, match="hour out of range"):
+        visitor.visit(astx.LiteralTime("25:00:00"))
+
+
+@pytest.mark.skipif(
+    not HAS_LITERAL_TIME, reason="astx.LiteralTime not available"
+)
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_literal_time_fractional_rejected(
+    builder_class: Type[Builder],
+) -> None:
+    """
+    title: Reject fractional seconds.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+    """
+    builder = builder_class()
+    visitor = cast(LLVMLiteIRVisitor, builder.translator)
+    visitor.result_stack.clear()
+    with pytest.raises(Exception, match="fractional seconds"):
+        visitor.visit(astx.LiteralTime("12:34:56.789"))


### PR DESCRIPTION
# Description

Closes #109 

This PR implements IR lowering support for `astx.LiteralTime` nodes in the LLVM-IR builder. 

### Implementation Details:
* **State Initialization**: Added a dedicated `TIME_TYPE` aggregate struct `{i32, i32, i32}` to `LLVMLiteState` to represent time payloads in the IR.
* **Visitor Support**: Added `@dispatch` implementation for [visit(self, node: astx.LiteralTime)](cci:1://file:///Users/jaskiratsingh/irx-1/src/irx/builders/llvmliteir.py:1841:4-1954:42) within [LLVMLiteIRVisitor](cci:2://file:///Users/jaskiratsingh/irx-1/src/irx/builders/llvmliteir.py:250:0-2884:40).
* **Behavior & Validation**:
  * Parses standard time strings and packs them into the `TIME_TYPE` struct as `ir.Constant` values (`[hour, minute, second]`).
  * Gracefully defaults seconds to `0` if omitted (e.g. `08:15` becomes `[8, 15, 0]`).
  * Implements strict validation to reject hours strictly outside the `0-23` range.
  * Rejects unsupported formats like fractional seconds (raises `"fractional seconds"` exception to ensure compatibility requirements are met).

### Testing:
Added [tests/test_literal_time.py](cci:7://file:///Users/jaskiratsingh/irx-1/tests/test_literal_time.py:0:0-0:0) with the following comprehensive coverage:
- ✅ [test_literal_time_hh_mm_ss](cci:1://file:///Users/jaskiratsingh/irx-1/tests/test_literal_time.py:32:0-56:35): Verifies standard `HH:MM:SS` parsing.
- ✅ [test_literal_time_hh_mm](cci:1://file:///Users/jaskiratsingh/irx-1/tests/test_literal_time.py:59:0-83:35): Verifies `HH:MM` defaulting for seconds.
- ✅ [test_literal_time_midnight](cci:1://file:///Users/jaskiratsingh/irx-1/tests/test_literal_time.py:86:0-110:35): Verifies bounds and zero-initialization at `00:00:00`.
- ✅ [test_literal_time_hour_out_of_range](cci:1://file:///Users/jaskiratsingh/irx-1/tests/test_literal_time.py:113:0-130:51): Bounds checks for invalid durations.
- ✅ [test_literal_time_fractional_rejected](cci:1://file:///Users/jaskiratsingh/irx-1/tests/test_literal_time.py:133:0-150:55): Rejection of unsupported fractional time markers.

All tests and pre-commit hooks (`ruff`, `douki`, `mypy`) pass locally.
