### PR TITLE
feat: add unsigned integer

### DIFF
--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -96,6 +96,11 @@ class VariablesLLVM:
     INT32_TYPE: ir.types.Type
     VOID_TYPE: ir.types.Type
     BOOLEAN_TYPE: ir.types.Type
+    UINT8_TYPE: ir.types.Type
+    UINT16_TYPE: ir.types.Type
+    UINT32_TYPE: ir.types.Type
+    UINT64_TYPE: ir.types.Type
+    UINT128_TYPE: ir.types.Type
     STRING_TYPE: ir.types.Type
     ASCII_STRING_TYPE: ir.types.Type
     UTF8_STRING_TYPE: ir.types.Type
@@ -145,6 +150,16 @@ class VariablesLLVM:
             return self.ASCII_STRING_TYPE
         elif type_name == "utf8string":
             return self.UTF8_STRING_TYPE
+        elif type_name == "uint8":
+            return self.UINT8_TYPE
+        elif type_name == "uint16":
+            return self.UINT16_TYPE
+        elif type_name == "uint32":
+            return self.UINT32_TYPE
+        elif type_name == "uint64":
+            return self.UINT64_TYPE
+        elif type_name == "uint128":
+            return self.UINT128_TYPE
         elif type_name == "nonetype":
             return self.VOID_TYPE
 
@@ -247,6 +262,11 @@ class LLVMLiteIRVisitor(BuilderVisitor):
         self._llvm.INT16_TYPE = ir.IntType(16)
         self._llvm.INT32_TYPE = ir.IntType(32)
         self._llvm.INT64_TYPE = ir.IntType(64)
+        self._llvm.UINT8_TYPE = ir.IntType(8)
+        self._llvm.UINT16_TYPE = ir.IntType(16)
+        self._llvm.UINT32_TYPE = ir.IntType(32)
+        self._llvm.UINT64_TYPE = ir.IntType(64)
+        self._llvm.UINT128_TYPE = ir.IntType(128)
         self._llvm.VOID_TYPE = ir.VoidType()
         self._llvm.STRING_TYPE = ir.LiteralStructType(
             [ir.IntType(32), ir.IntType(8).as_pointer()]
@@ -1316,6 +1336,36 @@ class LLVMLiteIRVisitor(BuilderVisitor):
     def visit(self, node: astx.LiteralInt8) -> None:
         """Translate ASTx LiteralInt8 to LLVM-IR."""
         result = ir.Constant(self._llvm.INT8_TYPE, node.value)
+        self.result_stack.append(result)
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.LiteralUInt8) -> None:
+        """Translate ASTx LiteralUInt8 to LLVM-IR."""
+        result = ir.Constant(self._llvm.UINT8_TYPE, node.value)
+        self.result_stack.append(result)
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.LiteralUInt16) -> None:
+        """Translate ASTx LiteralUInt16 to LLVM-IR."""
+        result = ir.Constant(self._llvm.UINT16_TYPE, node.value)
+        self.result_stack.append(result)
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.LiteralUInt32) -> None:
+        """Translate ASTx LiteralUInt32 to LLVM-IR."""
+        result = ir.Constant(self._llvm.UINT32_TYPE, node.value)
+        self.result_stack.append(result)
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.LiteralUInt64) -> None:
+        """Translate ASTx LiteralUInt64 to LLVM-IR."""
+        result = ir.Constant(self._llvm.UINT64_TYPE, node.value)
+        self.result_stack.append(result)
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.LiteralUInt128) -> None:
+        """Translate ASTx LiteralUInt128 to LLVM-IR."""
+        result = ir.Constant(self._llvm.UINT128_TYPE, node.value)
         self.result_stack.append(result)
 
     @dispatch  # type: ignore[no-redef]

--- a/tests/test_binary_op.py
+++ b/tests/test_binary_op.py
@@ -14,7 +14,12 @@ from .conftest import check_result
 
 @pytest.mark.parametrize(
     "int_type, literal_type",
-    [(astx.Int32, astx.LiteralInt32), (astx.Int16, astx.LiteralInt16)],
+    [
+        (astx.Int32, astx.LiteralInt32),
+        (astx.Int16, astx.LiteralInt16),
+        (astx.UInt32, astx.LiteralUInt32),
+        (astx.UInt16, astx.LiteralUInt16),
+    ],
 )
 @pytest.mark.parametrize(
     "builder_class",
@@ -59,6 +64,10 @@ def test_binary_op_literals(
         (astx.Int16, astx.LiteralInt16),
         (astx.Int8, astx.LiteralInt8),
         (astx.Int64, astx.LiteralInt64),
+        (astx.UInt32, astx.LiteralUInt32),
+        (astx.UInt16, astx.LiteralUInt16),
+        (astx.UInt8, astx.LiteralUInt8),
+        (astx.UInt64, astx.LiteralUInt64),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/test_unary_op.py
+++ b/tests/test_unary_op.py
@@ -18,6 +18,10 @@ from .conftest import check_result
         (astx.Int16, astx.LiteralInt16),
         (astx.Int8, astx.LiteralInt8),
         (astx.Int64, astx.LiteralInt64),
+        (astx.UInt32, astx.LiteralUInt32),
+        (astx.UInt16, astx.LiteralUInt16),
+        (astx.UInt8, astx.LiteralUInt8),
+        (astx.UInt64, astx.LiteralUInt64),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Notes

- This repository uses an AI bot for reviews. Keep your PR in **Draft** while
  you work. When you’re ready for a review, change the status to **Ready for
  review** to trigger a new review round. If you make additional changes and
  don’t want to trigger the bot, switch the PR back to **Draft**.
- AI-bot comments may not always be accurate. Please review them critically and
  share your feedback; it helps us improve the tool.
- Avoid changing code that is unrelated to your proposal. Keep your PR as short
  as possible to increase the chances of a timely review. Large PRs may not be
  reviewed and may be closed.
- Don’t add unnecessary comments. Your code should be readable and
  self-documenting
  ([guidance](https://google.github.io/styleguide/cppguide.html#Comments)).
- Don’t change core features without prior discussion with the community. Use
  our Discord to discuss ideas, blockers, or issues
  (https://discord.gg/Nu4MdGj9jB).
- Do not include secrets (API keys, tokens, passwords), credentials, or
  sensitive data/PII in code, configs, logs, screenshots, or commit history. If
  something leaks, rotate the credentials immediately, invalidate the old key,
  and note it in the PR so maintainers can assist.
- Do not commit large binaries or generated artifacts. If large datasets are
  needed for tests, prefer small fixtures or programmatic downloads declared in
  makim.yaml (e.g., a task that fetches data at test time). If a large binary is
  unavoidable, discuss first and consider Git LFS.

## Pull Request description

Add codegen support for `astx.LiteralUInt8`, `LiteralUInt16`, `LiteralUInt32`, `LiteralUInt64`, and `LiteralUInt128` in the LLVM-IR backend.
Solve #181 

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

- `pytest tests/test_binary_op.py tests/test_unary_op.py -v`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

**Code location:**
- File: `src/irx/builders/llvmliteir.py`
- VariablesLLVM, get_data_type, LLVMLiteIRVisitor

**Note on signedness:** LLVM uses the same integer type (`i32`, `i64`, etc.) for both signed and unsigned values with the distinction only applies at the instruction level. Signed-specific operations like comparisons and division are left for a follow-up, as they need a design decision on how to carry signedness information through the IR.

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
