### PR TITLE
feat: add unsigned integer

### DIFF
--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -160,6 +160,16 @@ class VariablesLLVM:
         type: ir.types.Type
       BOOLEAN_TYPE:
         type: ir.types.Type
+      UINT8_TYPE:
+        type: ir.types.Type
+      UINT16_TYPE:
+        type: ir.types.Type
+      UINT32_TYPE:
+        type: ir.types.Type
+      UINT64_TYPE:
+        type: ir.types.Type
+      UINT128_TYPE:
+        type: ir.types.Type
       STRING_TYPE:
         type: ir.types.Type
       ASCII_STRING_TYPE:
@@ -191,6 +201,11 @@ class VariablesLLVM:
     INT32_TYPE: ir.types.Type
     VOID_TYPE: ir.types.Type
     BOOLEAN_TYPE: ir.types.Type
+    UINT8_TYPE: ir.types.Type
+    UINT16_TYPE: ir.types.Type
+    UINT32_TYPE: ir.types.Type
+    UINT64_TYPE: ir.types.Type
+    UINT128_TYPE: ir.types.Type
     STRING_TYPE: ir.types.Type
     ASCII_STRING_TYPE: ir.types.Type
     UTF8_STRING_TYPE: ir.types.Type
@@ -239,6 +254,16 @@ class VariablesLLVM:
             return self.ASCII_STRING_TYPE
         elif type_name == "utf8string":
             return self.UTF8_STRING_TYPE
+        elif type_name == "uint8":
+            return self.UINT8_TYPE
+        elif type_name == "uint16":
+            return self.UINT16_TYPE
+        elif type_name == "uint32":
+            return self.UINT32_TYPE
+        elif type_name == "uint64":
+            return self.UINT64_TYPE
+        elif type_name == "uint128":
+            return self.UINT128_TYPE
         elif type_name == "nonetype":
             return self.VOID_TYPE
 
@@ -375,6 +400,11 @@ class LLVMLiteIRVisitor(BuilderVisitor):
         self._llvm.INT16_TYPE = ir.IntType(16)
         self._llvm.INT32_TYPE = ir.IntType(32)
         self._llvm.INT64_TYPE = ir.IntType(64)
+        self._llvm.UINT8_TYPE = ir.IntType(8)
+        self._llvm.UINT16_TYPE = ir.IntType(16)
+        self._llvm.UINT32_TYPE = ir.IntType(32)
+        self._llvm.UINT64_TYPE = ir.IntType(64)
+        self._llvm.UINT128_TYPE = ir.IntType(128)
         self._llvm.VOID_TYPE = ir.VoidType()
         self._llvm.STRING_TYPE = ir.LiteralStructType(
             [ir.IntType(32), ir.IntType(8).as_pointer()]
@@ -1563,6 +1593,61 @@ class LLVMLiteIRVisitor(BuilderVisitor):
             type: astx.LiteralInt8
         """
         result = ir.Constant(self._llvm.INT8_TYPE, node.value)
+        self.result_stack.append(result)
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.LiteralUInt8) -> None:
+        """
+        title: Translate ASTx LiteralUInt8 to LLVM-IR.
+        parameters:
+          node:
+            type: astx.LiteralUInt8
+        """
+        result = ir.Constant(self._llvm.UINT8_TYPE, node.value)
+        self.result_stack.append(result)
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.LiteralUInt16) -> None:
+        """
+        title: Translate ASTx LiteralUInt16 to LLVM-IR.
+        parameters:
+          node:
+            type: astx.LiteralUInt16
+        """
+        result = ir.Constant(self._llvm.UINT16_TYPE, node.value)
+        self.result_stack.append(result)
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.LiteralUInt32) -> None:
+        """
+        title: Translate ASTx LiteralUInt32 to LLVM-IR.
+        parameters:
+          node:
+            type: astx.LiteralUInt32
+        """
+        result = ir.Constant(self._llvm.UINT32_TYPE, node.value)
+        self.result_stack.append(result)
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.LiteralUInt64) -> None:
+        """
+        title: Translate ASTx LiteralUInt64 to LLVM-IR.
+        parameters:
+          node:
+            type: astx.LiteralUInt64
+        """
+        result = ir.Constant(self._llvm.UINT64_TYPE, node.value)
+        self.result_stack.append(result)
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.LiteralUInt128) -> None:
+        """
+        title: Translate ASTx LiteralUInt128 to LLVM-IR.
+        parameters:
+          node:
+            type: astx.LiteralUInt128
+        """
+        result = ir.Constant(self._llvm.UINT128_TYPE, node.value)
         self.result_stack.append(result)
 
     @dispatch  # type: ignore[no-redef]

--- a/tests/test_binary_op.py
+++ b/tests/test_binary_op.py
@@ -16,7 +16,12 @@ from .conftest import check_result
 
 @pytest.mark.parametrize(
     "int_type, literal_type",
-    [(astx.Int32, astx.LiteralInt32), (astx.Int16, astx.LiteralInt16)],
+    [
+        (astx.Int32, astx.LiteralInt32),
+        (astx.Int16, astx.LiteralInt16),
+        (astx.UInt32, astx.LiteralUInt32),
+        (astx.UInt16, astx.LiteralUInt16),
+    ],
 )
 @pytest.mark.parametrize(
     "builder_class",
@@ -70,6 +75,10 @@ def test_binary_op_literals(
         (astx.Int16, astx.LiteralInt16),
         (astx.Int8, astx.LiteralInt8),
         (astx.Int64, astx.LiteralInt64),
+        (astx.UInt32, astx.LiteralUInt32),
+        (astx.UInt16, astx.LiteralUInt16),
+        (astx.UInt8, astx.LiteralUInt8),
+        (astx.UInt64, astx.LiteralUInt64),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/test_unary_op.py
+++ b/tests/test_unary_op.py
@@ -20,6 +20,10 @@ from .conftest import check_result
         (astx.Int16, astx.LiteralInt16),
         (astx.Int8, astx.LiteralInt8),
         (astx.Int64, astx.LiteralInt64),
+        (astx.UInt32, astx.LiteralUInt32),
+        (astx.UInt16, astx.LiteralUInt16),
+        (astx.UInt8, astx.LiteralUInt8),
+        (astx.UInt64, astx.LiteralUInt64),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Pull Request description

Add codegen support for `astx.LiteralUInt8`, `LiteralUInt16`, `LiteralUInt32`, `LiteralUInt64`, and `LiteralUInt128` in the LLVM-IR backend.
Solve #181 

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

- `pytest tests/test_binary_op.py tests/test_unary_op.py -v`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

**Code location:**
- File: `src/irx/builders/llvmliteir.py`
- VariablesLLVM, get_data_type, LLVMLiteIRVisitor

**Note on signedness:** LLVM uses the same integer type (`i32`, `i64`, etc.) for both signed and unsigned values with the distinction only applies at the instruction level. Signed-specific operations like comparisons and division are left for a follow-up, as they need a design decision on how to carry signedness information through the IR.
References
- [https://discourse.llvm.org/t/explicitly-signed-unsigned-integers-in-std/731](https://discourse.llvm.org/t/explicitly-signed-unsigned-integers-in-std/731)
- [https://nondot.org/~sabre/LLVMNotes/TypeSystemChanges.txt](https://nondot.org/~sabre/LLVMNotes/TypeSystemChanges.txt)

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
