### PR TITLE
added list operation support

### DIFF
--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -1916,6 +1916,222 @@ class LLVMLiteIRVisitor(BuilderVisitor):
             "are supported"
         )
 
+    def _pop_result_or_raise(self, context: str) -> ir.Value:
+        """
+        title: Pop one value from result stack with context.
+        parameters:
+          context:
+            type: str
+        returns:
+          type: ir.Value
+        """
+        try:
+            value = self.result_stack.pop()
+        except IndexError as exc:
+            raise TypeError(f"{context}: lowering produced no value") from exc
+        if value is None:
+            raise TypeError(f"{context}: lowering produced None value")
+        return cast(ir.Value, value)
+
+    def _extract_int_array_constant(
+        self, value: ir.Value, context: str
+    ) -> tuple[ir.IntType, list[ir.Constant]]:
+        """
+        title: Ensure value is an integer array constant and unpack elements.
+        parameters:
+          value:
+            type: ir.Value
+          context:
+            type: str
+        returns:
+          type: tuple[ir.IntType, list[ir.Constant]]
+        """
+        if not isinstance(value, ir.Constant):
+            raise TypeError(f"{context}: expected array constant list value")
+        if not isinstance(value.type, ir.ArrayType):
+            raise TypeError(f"{context}: expected list as LLVM array type")
+        if not isinstance(value.type.element, ir.IntType):
+            raise TypeError(f"{context}: only integer lists are supported")
+
+        elem_ty = value.type.element
+        elems = value.constant
+        if not isinstance(elems, list):
+            raise TypeError(f"{context}: invalid constant array payload")
+
+        for idx, elem in enumerate(elems):
+            if not isinstance(elem, ir.Constant):
+                raise TypeError(
+                    f"{context}: list element {idx} is not constant"
+                )
+            if elem.type != elem_ty:
+                raise TypeError(
+                    f"{context}: list element {idx} type mismatch "
+                    f"{elem.type} != {elem_ty}"
+                )
+        return elem_ty, cast(list[ir.Constant], elems)
+
+    def _coerce_int_constant(
+        self, value: ir.Value, target_type: ir.IntType, context: str
+    ) -> ir.Constant:
+        """
+        title: Convert integer constant to requested integer type.
+        parameters:
+          value:
+            type: ir.Value
+          target_type:
+            type: ir.IntType
+          context:
+            type: str
+        returns:
+          type: ir.Constant
+        """
+        if not isinstance(value, ir.Constant):
+            raise TypeError(f"{context}: expected constant integer value")
+        if not isinstance(value.type, ir.IntType):
+            raise TypeError(f"{context}: expected integer value")
+        return ir.Constant(target_type, int(value.constant))
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: system.ListInsertExpr) -> None:
+        """
+        title: Insert value into an integer list constant.
+        parameters:
+          node:
+            type: system.ListInsertExpr
+        """
+        context = "ListInsertExpr"
+        self.visit(node.list_expr)
+        list_value = self._pop_result_or_raise(context)
+        elem_ty, elems = self._extract_int_array_constant(list_value, context)
+
+        self.visit(node.index)
+        index_value = self._pop_result_or_raise(context)
+        if not isinstance(index_value, ir.Constant) or not isinstance(
+            index_value.type, ir.IntType
+        ):
+            raise TypeError("ListInsertExpr: index must be integer constant")
+        index = int(index_value.constant)
+
+        self.visit(node.value)
+        inserted = self._coerce_int_constant(
+            self._pop_result_or_raise(context), elem_ty, context
+        )
+
+        out = list(elems)
+        out.insert(index, inserted)
+        out_ty = ir.ArrayType(elem_ty, len(out))
+        self.result_stack.append(ir.Constant(out_ty, out))
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: system.ListRemoveExpr) -> None:
+        """
+        title: Remove first matching value from integer list constant.
+        parameters:
+          node:
+            type: system.ListRemoveExpr
+        """
+        context = "ListRemoveExpr"
+        self.visit(node.list_expr)
+        list_value = self._pop_result_or_raise(context)
+        elem_ty, elems = self._extract_int_array_constant(list_value, context)
+
+        self.visit(node.value)
+        needle = self._coerce_int_constant(
+            self._pop_result_or_raise(context), elem_ty, context
+        )
+        needle_value = int(needle.constant)
+
+        out = list(elems)
+        for idx, elem in enumerate(out):
+            if int(elem.constant) == needle_value:
+                del out[idx]
+                out_ty = ir.ArrayType(elem_ty, len(out))
+                self.result_stack.append(ir.Constant(out_ty, out))
+                return
+
+        raise ValueError(
+            f"ListRemoveExpr: value {needle_value} not found in list"
+        )
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: system.ListSearchExpr) -> None:
+        """
+        title: Search first index of value in integer list constant.
+        parameters:
+          node:
+            type: system.ListSearchExpr
+        """
+        context = "ListSearchExpr"
+        self.visit(node.list_expr)
+        list_value = self._pop_result_or_raise(context)
+        elem_ty, elems = self._extract_int_array_constant(list_value, context)
+
+        self.visit(node.value)
+        needle = self._coerce_int_constant(
+            self._pop_result_or_raise(context), elem_ty, context
+        )
+        needle_value = int(needle.constant)
+
+        idx = -1
+        for pos, elem in enumerate(elems):
+            if int(elem.constant) == needle_value:
+                idx = pos
+                break
+        self.result_stack.append(ir.Constant(self._llvm.INT32_TYPE, idx))
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: system.ListCountExpr) -> None:
+        """
+        title: Count value occurrences in integer list constant.
+        parameters:
+          node:
+            type: system.ListCountExpr
+        """
+        context = "ListCountExpr"
+        self.visit(node.list_expr)
+        list_value = self._pop_result_or_raise(context)
+        elem_ty, elems = self._extract_int_array_constant(list_value, context)
+
+        self.visit(node.value)
+        needle = self._coerce_int_constant(
+            self._pop_result_or_raise(context), elem_ty, context
+        )
+        needle_value = int(needle.constant)
+
+        count = sum(1 for elem in elems if int(elem.constant) == needle_value)
+        self.result_stack.append(ir.Constant(self._llvm.INT32_TYPE, count))
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: system.ListSliceExpr) -> None:
+        """
+        title: Slice integer list constant using Python-style bounds.
+        parameters:
+          node:
+            type: system.ListSliceExpr
+        """
+        context = "ListSliceExpr"
+        self.visit(node.list_expr)
+        list_value = self._pop_result_or_raise(context)
+        elem_ty, elems = self._extract_int_array_constant(list_value, context)
+
+        self.visit(node.start)
+        start_value = self._pop_result_or_raise(context)
+        self.visit(node.end)
+        end_value = self._pop_result_or_raise(context)
+
+        if not isinstance(start_value, ir.Constant) or not isinstance(
+            start_value.type, ir.IntType
+        ):
+            raise TypeError("ListSliceExpr: start must be integer constant")
+        if not isinstance(end_value, ir.Constant) or not isinstance(
+            end_value.type, ir.IntType
+        ):
+            raise TypeError("ListSliceExpr: end must be integer constant")
+
+        sliced = elems[int(start_value.constant) : int(end_value.constant)]
+        out_ty = ir.ArrayType(elem_ty, len(sliced))
+        self.result_stack.append(ir.Constant(out_ty, sliced))
+
     def _create_string_concat_function(self) -> ir.Function:
         """
         title: Create a string concatenation function.
@@ -2848,5 +3064,7 @@ class LLVMLiteIR(Builder):
             file_path_o,
             "-o",
             self.output_file,
+            _tty_out=False,
+            _tty_in=False,
         )
         os.chmod(self.output_file, 0o755)

--- a/src/irx/system.py
+++ b/src/irx/system.py
@@ -81,3 +81,187 @@ class Cast(astx.Expr):
         key = f"Cast[{self.target_type}]"
         value = self.value.get_struct(simplified)
         return self._prepare_struct(key, value, simplified)
+
+
+class ListInsertExpr(astx.Expr):
+    """
+    title: Insert an element into a list expression.
+    attributes:
+      list_expr:
+        type: astx.Expr
+      index:
+        type: astx.Expr
+      value:
+        type: astx.Expr
+    """
+
+    list_expr: astx.Expr
+    index: astx.Expr
+    value: astx.Expr
+
+    def __init__(
+        self, list_expr: astx.Expr, index: astx.Expr, value: astx.Expr
+    ) -> None:
+        self.list_expr = list_expr
+        self.index = index
+        self.value = value
+
+    def get_struct(self, simplified: bool = False) -> astx.base.ReprStruct:
+        """
+        title: Return the structured representation of list insert.
+        parameters:
+          simplified:
+            type: bool
+        returns:
+          type: astx.base.ReprStruct
+        """
+        key = "ListInsertExpr"
+        value = {
+            "list": self.list_expr.get_struct(simplified),
+            "index": self.index.get_struct(simplified),
+            "value": self.value.get_struct(simplified),
+        }
+        return self._prepare_struct(key, value, simplified)
+
+
+class ListRemoveExpr(astx.Expr):
+    """
+    title: Remove the first matching element from a list expression.
+    attributes:
+      list_expr:
+        type: astx.Expr
+      value:
+        type: astx.Expr
+    """
+
+    list_expr: astx.Expr
+    value: astx.Expr
+
+    def __init__(self, list_expr: astx.Expr, value: astx.Expr) -> None:
+        self.list_expr = list_expr
+        self.value = value
+
+    def get_struct(self, simplified: bool = False) -> astx.base.ReprStruct:
+        """
+        title: Return the structured representation of list remove.
+        parameters:
+          simplified:
+            type: bool
+        returns:
+          type: astx.base.ReprStruct
+        """
+        key = "ListRemoveExpr"
+        value = {
+            "list": self.list_expr.get_struct(simplified),
+            "value": self.value.get_struct(simplified),
+        }
+        return self._prepare_struct(key, value, simplified)
+
+
+class ListSearchExpr(astx.Expr):
+    """
+    title: Search an element in a list expression.
+    attributes:
+      list_expr:
+        type: astx.Expr
+      value:
+        type: astx.Expr
+    """
+
+    list_expr: astx.Expr
+    value: astx.Expr
+
+    def __init__(self, list_expr: astx.Expr, value: astx.Expr) -> None:
+        self.list_expr = list_expr
+        self.value = value
+
+    def get_struct(self, simplified: bool = False) -> astx.base.ReprStruct:
+        """
+        title: Return the structured representation of list search.
+        parameters:
+          simplified:
+            type: bool
+        returns:
+          type: astx.base.ReprStruct
+        """
+        key = "ListSearchExpr"
+        value = {
+            "list": self.list_expr.get_struct(simplified),
+            "value": self.value.get_struct(simplified),
+        }
+        return self._prepare_struct(key, value, simplified)
+
+
+class ListCountExpr(astx.Expr):
+    """
+    title: Count element occurrences in a list expression.
+    attributes:
+      list_expr:
+        type: astx.Expr
+      value:
+        type: astx.Expr
+    """
+
+    list_expr: astx.Expr
+    value: astx.Expr
+
+    def __init__(self, list_expr: astx.Expr, value: astx.Expr) -> None:
+        self.list_expr = list_expr
+        self.value = value
+
+    def get_struct(self, simplified: bool = False) -> astx.base.ReprStruct:
+        """
+        title: Return the structured representation of list count.
+        parameters:
+          simplified:
+            type: bool
+        returns:
+          type: astx.base.ReprStruct
+        """
+        key = "ListCountExpr"
+        value = {
+            "list": self.list_expr.get_struct(simplified),
+            "value": self.value.get_struct(simplified),
+        }
+        return self._prepare_struct(key, value, simplified)
+
+
+class ListSliceExpr(astx.Expr):
+    """
+    title: Slice a list expression using start and end.
+    attributes:
+      list_expr:
+        type: astx.Expr
+      start:
+        type: astx.Expr
+      end:
+        type: astx.Expr
+    """
+
+    list_expr: astx.Expr
+    start: astx.Expr
+    end: astx.Expr
+
+    def __init__(
+        self, list_expr: astx.Expr, start: astx.Expr, end: astx.Expr
+    ) -> None:
+        self.list_expr = list_expr
+        self.start = start
+        self.end = end
+
+    def get_struct(self, simplified: bool = False) -> astx.base.ReprStruct:
+        """
+        title: Return the structured representation of list slice.
+        parameters:
+          simplified:
+            type: bool
+        returns:
+          type: astx.base.ReprStruct
+        """
+        key = "ListSliceExpr"
+        value = {
+            "list": self.list_expr.get_struct(simplified),
+            "start": self.start.get_struct(simplified),
+            "end": self.end.get_struct(simplified),
+        }
+        return self._prepare_struct(key, value, simplified)

--- a/tests/test_list_operations.py
+++ b/tests/test_list_operations.py
@@ -1,0 +1,215 @@
+"""
+title: Tests for list operations lowering.
+"""
+
+from __future__ import annotations
+
+from typing import Type, cast
+
+import astx
+import pytest
+
+from irx import system
+from irx.builders.base import Builder
+from irx.builders.llvmliteir import LLVMLiteIR, LLVMLiteIRVisitor
+from llvmlite import ir
+
+
+def _lower(node: astx.AST, builder_class: Type[Builder]) -> ir.Value:
+    """
+    title: Lower one AST node and return resulting value.
+    parameters:
+      node:
+        type: astx.AST
+      builder_class:
+        type: Type[Builder]
+    returns:
+      type: ir.Value
+    """
+    builder = builder_class()
+    visitor = cast(LLVMLiteIRVisitor, builder.translator)
+    visitor.result_stack.clear()
+    visitor.visit(node)
+    return cast(ir.Value, visitor.result_stack.pop())
+
+
+def _array_values(const: ir.Constant) -> list[int]:
+    """
+    title: Extract integer values from a constant array.
+    parameters:
+      const:
+        type: ir.Constant
+    returns:
+      type: list[int]
+    """
+    assert isinstance(const.type, ir.ArrayType)
+    assert isinstance(const.type.element, ir.IntType)
+    return [int(elem.constant) for elem in const.constant]
+
+
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_list_insert(builder_class: Type[Builder]) -> None:
+    """
+    title: Insert updates list content and size.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+    """
+    list_expr = astx.LiteralList(
+        elements=[
+            astx.LiteralInt32(1),
+            astx.LiteralInt32(3),
+        ]
+    )
+    node = system.ListInsertExpr(
+        list_expr=list_expr,
+        index=astx.LiteralInt32(1),
+        value=astx.LiteralInt32(2),
+    )
+    result = _lower(node, builder_class)
+    assert isinstance(result, ir.Constant)
+    assert isinstance(result.type, ir.ArrayType)
+    assert result.type.count == 3  # noqa: PLR2004
+    assert _array_values(result) == [1, 2, 3]
+
+
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_list_remove(builder_class: Type[Builder]) -> None:
+    """
+    title: Remove deletes first matching value.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+    """
+    list_expr = astx.LiteralList(
+        elements=[
+            astx.LiteralInt32(1),
+            astx.LiteralInt32(2),
+            astx.LiteralInt32(2),
+            astx.LiteralInt32(3),
+        ]
+    )
+    node = system.ListRemoveExpr(
+        list_expr=list_expr,
+        value=astx.LiteralInt32(2),
+    )
+    result = _lower(node, builder_class)
+    assert isinstance(result, ir.Constant)
+    assert isinstance(result.type, ir.ArrayType)
+    assert result.type.count == 3  # noqa: PLR2004
+    assert _array_values(result) == [1, 2, 3]
+
+
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_list_search_found_and_missing(builder_class: Type[Builder]) -> None:
+    """
+    title: Search returns index or -1 when missing.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+    """
+    list_expr = astx.LiteralList(
+        elements=[
+            astx.LiteralInt32(10),
+            astx.LiteralInt32(20),
+            astx.LiteralInt32(30),
+        ]
+    )
+    found = _lower(
+        system.ListSearchExpr(
+            list_expr=list_expr,
+            value=astx.LiteralInt32(20),
+        ),
+        builder_class,
+    )
+    missing = _lower(
+        system.ListSearchExpr(
+            list_expr=list_expr,
+            value=astx.LiteralInt32(999),
+        ),
+        builder_class,
+    )
+    assert isinstance(found, ir.Constant)
+    assert isinstance(missing, ir.Constant)
+    assert int(found.constant) == 1
+    assert int(missing.constant) == -1
+
+
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_list_count(builder_class: Type[Builder]) -> None:
+    """
+    title: Count returns number of matching entries.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+    """
+    list_expr = astx.LiteralList(
+        elements=[
+            astx.LiteralInt32(5),
+            astx.LiteralInt32(5),
+            astx.LiteralInt32(6),
+            astx.LiteralInt32(5),
+        ]
+    )
+    result = _lower(
+        system.ListCountExpr(
+            list_expr=list_expr,
+            value=astx.LiteralInt32(5),
+        ),
+        builder_class,
+    )
+    assert isinstance(result, ir.Constant)
+    assert int(result.constant) == 3  # noqa: PLR2004
+
+
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_list_slice(builder_class: Type[Builder]) -> None:
+    """
+    title: Slice returns a new list for start:end bounds.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+    """
+    list_expr = astx.LiteralList(
+        elements=[
+            astx.LiteralInt32(0),
+            astx.LiteralInt32(1),
+            astx.LiteralInt32(2),
+            astx.LiteralInt32(3),
+        ]
+    )
+    result = _lower(
+        system.ListSliceExpr(
+            list_expr=list_expr,
+            start=astx.LiteralInt32(1),
+            end=astx.LiteralInt32(3),
+        ),
+        builder_class,
+    )
+    assert isinstance(result, ir.Constant)
+    assert isinstance(result.type, ir.ArrayType)
+    assert result.type.count == 2  # noqa: PLR2004
+    assert _array_values(result) == [1, 2]
+
+
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_list_remove_raises_when_value_missing(
+    builder_class: Type[Builder],
+) -> None:
+    """
+    title: Remove raises if value does not exist.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+    """
+    list_expr = astx.LiteralList(
+        elements=[astx.LiteralInt32(1), astx.LiteralInt32(2)]
+    )
+    with pytest.raises(ValueError, match="not found"):
+        _lower(
+            system.ListRemoveExpr(
+                list_expr=list_expr,
+                value=astx.LiteralInt32(42),
+            ),
+            builder_class,
+        )


### PR DESCRIPTION
Added new list-op AST expression nodes in src/irx/system.py: ListInsertExpr
ListRemoveExpr
ListSearchExpr
ListCountExpr
ListSliceExpr
Added lowering support in src/irx/builders/llvmliteir.py for all five operations: visit(system.ListInsertExpr)
visit(system.ListRemoveExpr)
visit(system.ListSearchExpr)
visit(system.ListCountExpr)
visit(system.ListSliceExpr)
Added internal helpers in the visitor to keep behavior safe and consistent: result-stack pop with clear errors
integer-array constant validation
integer constant coercion to list element width

Behavior implemented
Supports operations over the currently supported list shape: LLVM integer array constants. insert: inserts at index (Python-style list.insert behavior). remove: removes first matching value; raises ValueError if not found. search: returns first index, or -1 if missing.
count: returns match count.
slice: returns start:end slice (Python-style bounds handling). 

Tests added
New file: tests/test_list_operations.py
Covers:
insert
remove
search (found + missing)
count
slice
remove-not-found error path

Validation
Ran the new test file successfully: 6 passed.
Checked lints for touched files: no linter errors.

