### PR TITLE
fix: default vector int division to signed to match scalar behavior

### DIFF
--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -933,12 +933,11 @@ class LLVMLiteIRVisitor(BuilderVisitor):
                         )
                         self._apply_fast_math(result)
                     else:
-                        unsigned = getattr(node, "unsigned", None)
+                        unsigned = getattr(node, "unsigned", False)
                         if unsigned is None:
-                            raise Exception(
-                                "Cannot infer integer division signedness "
-                                "for vector op"
-                            )
+                            # Fallback to signed division (sdiv) by default
+                            unsigned = False
+
                         result = emit_int_div(
                             self._llvm.ir_builder, llvm_lhs, llvm_rhs, unsigned
                         )


### PR DESCRIPTION
Fixes the bug reported in the issue regarding inconsistent astx.BinaryOp signedness fallback between scalar and vector operands.

Changes Made:

Updated the vector integer division logic in src/irx/builders/llvmliteir.py to default to unsigned = False (signed division via sdiv) when the unsigned attribute is omitted or set to None.
This unifies the vector fallback logic with the existing scalar fallback behavior and prevents the compiler from throwing an unexpected fatal Exception.
(Tested locally and verified against the existing AST constraint test suite).

