### PR TITLE
Fix LiteralUTF8Char lowering for non-ASCII UTF-8 chars

### DIFF
--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -1654,7 +1654,7 @@ class LLVMLiteIRVisitor(BuilderVisitor):
     @dispatch  # type: ignore[no-redef]
     def visit(self, expr: astx.LiteralUTF8Char) -> None:
         """
-        title: Handle ASCII string literals.
+        title: Handle UTF-8 char literals.
         parameters:
           expr:
             type: astx.LiteralUTF8Char
@@ -1673,7 +1673,7 @@ class LLVMLiteIRVisitor(BuilderVisitor):
         string_data.linkage = "internal"
         string_data.global_constant = True
         string_data.initializer = ir.Constant(
-            string_data_type, bytearray(string_value + "\0", "ascii")
+            string_data_type, bytearray(utf8_bytes + b"\0")
         )
 
         ptr = self._llvm.ir_builder.gep(

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -10,6 +10,7 @@ import pytest
 from irx.builders.base import Builder
 from irx.builders.llvmliteir import LLVMLiteIR
 from irx.system import PrintExpr
+from llvmlite import binding as llvm
 
 from .conftest import check_result
 
@@ -82,6 +83,43 @@ def test_string_literal_utf8_char_with_print(
     module.block.append(fn)
 
     check_result("build", builder, module, expected_output=expected)
+
+
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_string_literal_utf8_char_non_ascii_translate(
+    builder_class: Type[Builder],
+) -> None:
+    """
+    title: Test non-ASCII UTF-8 char literal lowers without crashing.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+    """
+    builder = builder_class()
+    module = builder.module()
+
+    expected = "é"
+
+    char_literal = astx.LiteralUTF8Char(expected)
+
+    decl_tmp = astx.VariableDeclaration(
+        name="tmp", type_=astx.String(), value=char_literal
+    )
+
+    block = astx.Block()
+    block.append(decl_tmp)
+    block.append(PrintExpr(astx.LiteralUTF8String(expected)))
+    block.append(astx.FunctionReturn(astx.LiteralInt32(0)))
+
+    proto = astx.FunctionPrototype(
+        name="main", args=astx.Arguments(), return_type=astx.Int32()
+    )
+    fn = astx.FunctionDef(prototype=proto, body=block)
+    module.block.append(fn)
+
+    ir_text = builder.translate(module)
+
+    llvm.parse_assembly(ir_text)
 
 
 @pytest.mark.parametrize("builder_class", [LLVMLiteIR])


### PR DESCRIPTION
## Pull Request description

This PR fixes a Unicode lowering bug in `LiteralUTF8Char`.

When lowering `astx.LiteralUTF8Char`, the code correctly computed the UTF-8 byte length, but initialized the backing global constant using ASCII encoding. That caused translation to fail for valid non-ASCII characters such as `é` with a `UnicodeEncodeError`.

Changes made:
- use UTF-8 bytes when initializing `LiteralUTF8Char` storage
- add a regression test covering a multibyte UTF-8 char literal

Addresses #208 

## How to test these changes

- run `pytest tests/test_string.py -q -k "utf8_char_non_ascii_translate"`
- confirm the test passes
- optionally verify that lowering a module containing `astx.LiteralUTF8Char("é")` no longer raises `UnicodeEncodeError`

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

- Validation run locally:
  - `pytest tests/test_string.py -q -k "utf8_char_non_ascii_translate"` 
  - `ruff check src/irx/builders/llvmliteir.py tests/test_string.py` 
- I kept the change minimal and limited it to the UTF-8 char literal lowering path and one regression test.

## Reviewer's checklist

Copy and paste this template for your review's note:

```text
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .