### PR TITLE
refactor: use emit_add consistently in BinaryOp scalar addition

### DIFF
--- a/src/irx/builders/llvmliteir.py
+++ b/src/irx/builders/llvmliteir.py
@@ -999,15 +999,9 @@ class LLVMLiteIRVisitor(BuilderVisitor):
                 self.result_stack.append(result)
                 return
 
-            elif is_fp_type(llvm_lhs.type) or is_fp_type(llvm_rhs.type):
-                result = self._llvm.ir_builder.fadd(
-                    llvm_lhs, llvm_rhs, "addtmp"
-                )
-                self._apply_fast_math(result)
             else:
-                # there's more conditions to be handled
-                result = self._llvm.ir_builder.add(
-                    llvm_lhs, llvm_rhs, "addtmp"
+                result = emit_add(
+                    self._llvm.ir_builder, llvm_lhs, llvm_rhs, "addtmp"
                 )
             self.result_stack.append(result)
             return


### PR DESCRIPTION

## Changes Made

The scalar `+` operator branch in [LLVMLiteIRVisitor](cci:2://file:///Users/jaskiratsingh/irx-1/src/irx/builders/llvmliteir.py:277:0-3073:40) had an inline
`if is_fp_type → fadd / else → add` block that duplicated the logic
already encapsulated in the [emit_add](cci:1://file:///Users/jaskiratsingh/irx-1/src/irx/builders/llvmliteir.py:100:0-122:46) helper (introduced in #218).

Replaced the 8-line inline block with a single [emit_add(...)](cci:1://file:///Users/jaskiratsingh/irx-1/src/irx/builders/llvmliteir.py:100:0-122:46) call
for consistency.

## Notes

The vector-specific `fadd` (with `vfaddtmp` name) in the vector binary
op handler is intentionally unchanged — it is not the same pattern.

All 165 tests pass locally.
