### PR TITLE
feat: replace circular cast tests with meaningful coverage across all cast paths

### DIFF
--- a/tests/test_cast.py
+++ b/tests/test_cast.py
@@ -15,275 +15,53 @@ from .conftest import check_result
 
 
 @pytest.mark.parametrize(
-    "int_type_from, literal_type_from, int_type_to",
+    "int_type_from, literal_type_from, value, int_type_to, expected_output",
     [
-        (astx.Int8, astx.LiteralInt8, astx.Int32),
-        (astx.Int32, astx.LiteralInt32, astx.Int16),
-        (astx.Int16, astx.LiteralInt16, astx.Int8),
+        # widening: 42 fits fine, result is still "42"
+        (astx.Int8, astx.LiteralInt8, 42, astx.Int32, "42"),
+        # narrowing with truncation: 300 -> i8 = 44 (300 % 256)
+        (astx.Int32, astx.LiteralInt32, 300, astx.Int8, "44"),
+        # narrowing that fits: 42 -> i8 still "42"
+        (astx.Int16, astx.LiteralInt16, 42, astx.Int8, "42"),
     ],
 )
-@pytest.mark.parametrize(
-    "action,expected_file",
-    [
-        # ("translate", "test_cast_basic.ll"),
-        ("build", ""),
-    ],
-)
-@pytest.mark.parametrize(
-    "builder_class",
-    [
-        LLVMLiteIR,
-    ],
-)
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
 def test_cast_basic(
-    action: str,
-    expected_file: str,
     builder_class: Type[Builder],
     int_type_from: type,
     literal_type_from: type,
+    value: int,
     int_type_to: type,
+    expected_output: str,
 ) -> None:
     """
     title: Test casting int types between different widths.
     parameters:
-      action:
-        type: str
-      expected_file:
-        type: str
       builder_class:
         type: Type[Builder]
       int_type_from:
         type: type
       literal_type_from:
         type: type
+      value:
+        type: int
       int_type_to:
         type: type
-    """
-    builder = builder_class()
-    module = builder.module()
-
-    decl_a = astx.VariableDeclaration(
-        name="a", type_=int_type_from(), value=literal_type_from(42)
-    )
-    a = astx.Identifier("a")
-    cast_expr = Cast(value=a, target_type=int_type_to())
-
-    main_proto = astx.FunctionPrototype(
-        name="main", args=astx.Arguments(), return_type=int_type_to()
-    )
-    main_block = astx.Block()
-    main_block.append(decl_a)
-    cast_var = astx.InlineVariableDeclaration(
-        name="r", type_=int_type_to(), value=cast_expr
-    )
-    main_block.append(cast_var)
-    main_block.append(astx.FunctionReturn(astx.Identifier("r")))
-    main_fn = astx.FunctionDef(prototype=main_proto, body=main_block)
-
-    module.block.append(main_fn)
-
-    expected_output = "42"
-    check_result("build", builder, module, expected_output=expected_output)
-
-
-@pytest.mark.parametrize(
-    "builder_class",
-    [
-        LLVMLiteIR,
-    ],
-)
-def test_cast_int_to_float_and_back(builder_class: Type[Builder]) -> None:
-    """
-    title: Test casting int -> float -> int, returning int result.
-    parameters:
-      builder_class:
-        type: Type[Builder]
-    """
-    builder = builder_class()
-    module = builder.module()
-
-    # a: i32 = 42
-    decl_a = astx.VariableDeclaration(
-        name="a", type_=astx.Int32(), value=astx.LiteralInt32(42)
-    )
-    a_ident = astx.Identifier("a")
-
-    # r: float32 = cast(a)
-    cast_to_float = Cast(value=a_ident, target_type=astx.Float32())
-    cast_var_float = astx.InlineVariableDeclaration(
-        name="r", type_=astx.Float32(), value=cast_to_float
-    )
-
-    # s: int32 = cast(r)
-    r_ident = astx.Identifier("r")
-    cast_back_to_int = Cast(value=r_ident, target_type=astx.Int32())
-    cast_var_int = astx.InlineVariableDeclaration(
-        name="s", type_=astx.Int32(), value=cast_back_to_int
-    )
-
-    # main returns int32
-    main_proto = astx.FunctionPrototype(
-        name="main", args=astx.Arguments(), return_type=astx.Int32()
-    )
-    main_block = astx.Block()
-    main_block.append(decl_a)
-    main_block.append(cast_var_float)
-    main_block.append(cast_var_int)
-    main_block.append(astx.FunctionReturn(astx.Identifier("s")))
-    main_fn = astx.FunctionDef(prototype=main_proto, body=main_block)
-
-    module.block.append(main_fn)
-
-    # expected output: program exit code "42"
-    expected_output = "42"
-    check_result("build", builder, module, expected_output=expected_output)
-
-
-@pytest.mark.parametrize(
-    "builder_class",
-    [
-        LLVMLiteIR,
-    ],
-)
-def test_cast_int_to_string(builder_class: Type[Builder]) -> None:
-    """
-    title: Cast an integer to a string, print it, and return 0.
-    parameters:
-      builder_class:
-        type: Type[Builder]
-    """
-    builder = builder_class()
-    module = builder.module()
-
-    # a: i32 = 42
-    decl_a = astx.VariableDeclaration(
-        name="a", type_=astx.Int32(), value=astx.LiteralInt32(42)
-    )
-    a_ident = astx.Identifier("a")
-
-    # r: string = cast(a)
-    cast_to_str = Cast(value=a_ident, target_type=astx.String())
-    cast_var = astx.InlineVariableDeclaration(
-        name="r", type_=astx.String(), value=cast_to_str
-    )
-
-    # print(r)
-    print_stmt = PrintExpr(message=astx.Identifier("r"))
-
-    # main returns int32 (exit code 0)
-    main_proto = astx.FunctionPrototype(
-        name="main", args=astx.Arguments(), return_type=astx.Int32()
-    )
-    main_block = astx.Block()
-    main_block.append(decl_a)
-    main_block.append(cast_var)
-    main_block.append(print_stmt)
-    main_block.append(astx.FunctionReturn(astx.LiteralInt32(0)))
-    main_fn = astx.FunctionDef(prototype=main_proto, body=main_block)
-
-    module.block.append(main_fn)
-
-    expected_output = "42"
-    check_result("build", builder, module, expected_output=expected_output)
-
-
-@pytest.mark.parametrize(
-    "builder_class",
-    [
-        LLVMLiteIR,
-    ],
-)
-def test_cast_float_to_string(builder_class: Type[Builder]) -> None:
-    """
-    title: Cast a float to a string, print it, and return 0.
-    parameters:
-      builder_class:
-        type: Type[Builder]
-    """
-    builder = builder_class()
-    module = builder.module()
-
-    # a: float32 = 42.0
-    decl_a = astx.VariableDeclaration(
-        name="a", type_=astx.Float32(), value=astx.LiteralFloat32(42.0)
-    )
-    a_ident = astx.Identifier("a")
-
-    # r: string = cast(a)
-    cast_to_str = Cast(value=a_ident, target_type=astx.String())
-    cast_var = astx.InlineVariableDeclaration(
-        name="r", type_=astx.String(), value=cast_to_str
-    )
-
-    # print(r)
-    print_stmt = PrintExpr(message=astx.Identifier("r"))
-
-    # main returns int32 (exit code 0)
-    main_proto = astx.FunctionPrototype(
-        name="main", args=astx.Arguments(), return_type=astx.Int32()
-    )
-    main_block = astx.Block()
-    main_block.append(decl_a)
-    main_block.append(cast_var)
-    main_block.append(print_stmt)
-    main_block.append(astx.FunctionReturn(astx.LiteralInt32(0)))
-    main_fn = astx.FunctionDef(prototype=main_proto, body=main_block)
-
-    module.block.append(main_fn)
-
-    expected_output = "42.000000"
-    check_result("build", builder, module, expected_output=expected_output)
-
-
-@pytest.mark.parametrize(
-    "boolean_value, expected_output",
-    [
-        (True, "1"),
-        (False, "0"),
-    ],
-)
-@pytest.mark.parametrize(
-    "builder_class",
-    [
-        LLVMLiteIR,
-    ],
-)
-def test_cast_boolean_to_string(
-    builder_class: Type[Builder],
-    boolean_value: bool,
-    expected_output: str,
-) -> None:
-    """
-    title: Cast a boolean to a string, verify it prints as 1/0 not -1/0.
-    parameters:
-      builder_class:
-        type: Type[Builder]
-      boolean_value:
-        type: bool
       expected_output:
         type: str
     """
     builder = builder_class()
     module = builder.module()
 
-    # a: boolean = True/False
     decl_a = astx.VariableDeclaration(
-        name="a",
-        type_=astx.Boolean(),
-        value=astx.LiteralBoolean(boolean_value),
+        name="a", type_=int_type_from(), value=literal_type_from(value)
     )
-    a_ident = astx.Identifier("a")
-
-    # r: string = cast(a)
-    cast_to_str = Cast(value=a_ident, target_type=astx.String())
+    cast_expr = Cast(value=astx.Identifier("a"), target_type=int_type_to())
     cast_var = astx.InlineVariableDeclaration(
-        name="r", type_=astx.String(), value=cast_to_str
+        name="r", type_=int_type_to(), value=cast_expr
     )
-
-    # print(r)
     print_stmt = PrintExpr(message=astx.Identifier("r"))
 
-    # main returns int32 (exit code 0)
     main_proto = astx.FunctionPrototype(
         name="main", args=astx.Arguments(), return_type=astx.Int32()
     )
@@ -293,7 +71,222 @@ def test_cast_boolean_to_string(
     main_block.append(print_stmt)
     main_block.append(astx.FunctionReturn(astx.LiteralInt32(0)))
     main_fn = astx.FunctionDef(prototype=main_proto, body=main_block)
-
     module.block.append(main_fn)
 
     check_result("build", builder, module, expected_output=expected_output)
+
+
+@pytest.mark.parametrize(
+    "astx_type, literal_type, value, expected_output",
+    [
+        (astx.Int32, astx.LiteralInt32, 42, "42"),
+        (astx.Float32, astx.LiteralFloat32, 42.0, "42.000000"),
+        (astx.Boolean, astx.LiteralBoolean, True, "1"),
+        (astx.Boolean, astx.LiteralBoolean, False, "0"),
+    ],
+)
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_cast_to_string(
+    builder_class: Type[Builder],
+    astx_type: type,
+    literal_type: type,
+    value: object,
+    expected_output: str,
+) -> None:
+    """
+    title: Cast various types to string and verify printed output.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+      astx_type:
+        type: type
+      literal_type:
+        type: type
+      value:
+        type: object
+      expected_output:
+        type: str
+    """
+    builder = builder_class()
+    module = builder.module()
+
+    decl_a = astx.VariableDeclaration(
+        name="a", type_=astx_type(), value=literal_type(value)
+    )
+    cast_var = astx.InlineVariableDeclaration(
+        name="r",
+        type_=astx.String(),
+        value=Cast(value=astx.Identifier("a"), target_type=astx.String()),
+    )
+    print_stmt = PrintExpr(message=astx.Identifier("r"))
+
+    main_proto = astx.FunctionPrototype(
+        name="main", args=astx.Arguments(), return_type=astx.Int32()
+    )
+    main_block = astx.Block()
+    main_block.append(decl_a)
+    main_block.append(cast_var)
+    main_block.append(print_stmt)
+    main_block.append(astx.FunctionReturn(astx.LiteralInt32(0)))
+    module.block.append(
+        astx.FunctionDef(prototype=main_proto, body=main_block)
+    )
+
+    check_result("build", builder, module, expected_output=expected_output)
+
+
+@pytest.mark.parametrize(
+    "int_type, literal_type, expected_str",
+    [
+        (astx.Int32, astx.LiteralInt32, "7.000000"),
+        (astx.Int8, astx.LiteralInt8, "7.000000"),
+        (astx.Int64, astx.LiteralInt64, "7.000000"),
+    ],
+)
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_cast_int_to_float(
+    builder_class: Type[Builder],
+    int_type: type,
+    literal_type: type,
+    expected_str: str,
+) -> None:
+    """
+    title: Cast int to float.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+      int_type:
+        type: type
+      literal_type:
+        type: type
+      expected_str:
+        type: str
+    """
+    builder = builder_class()
+    module = builder.module()
+
+    # a: int = 7
+    decl_a = astx.VariableDeclaration(
+        name="a", type_=int_type(), value=literal_type(7)
+    )
+
+    # r: float32 = cast(a)
+    cast_expr = Cast(value=astx.Identifier("a"), target_type=astx.Float32())
+    cast_var = astx.InlineVariableDeclaration(
+        name="r", type_=astx.Float32(), value=cast_expr
+    )
+
+    # print(r)  -- will show "7.000000" proving the cast actually happened
+    print_stmt = PrintExpr(message=astx.Identifier("r"))
+
+    main_proto = astx.FunctionPrototype(
+        name="main", args=astx.Arguments(), return_type=astx.Int32()
+    )
+    main_block = astx.Block()
+    main_block.append(decl_a)
+    main_block.append(cast_var)
+    main_block.append(print_stmt)
+    main_block.append(astx.FunctionReturn(astx.LiteralInt32(0)))
+    main_fn = astx.FunctionDef(prototype=main_proto, body=main_block)
+    module.block.append(main_fn)
+
+    check_result("build", builder, module, expected_output=expected_str)
+
+
+@pytest.mark.parametrize(
+    "float_type, literal_type, value, int_type, expected_output",
+    [
+        # truncates toward zero, not rounds
+        (astx.Float32, astx.LiteralFloat32, 7.9, astx.Int32, "7"),
+        (astx.Float32, astx.LiteralFloat32, 7.1, astx.Int32, "7"),
+        # negative truncation
+        (astx.Float32, astx.LiteralFloat32, -3.9, astx.Int32, "-3"),
+    ],
+)
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_cast_float_to_int(
+    builder_class: Type[Builder],
+    float_type: type,
+    literal_type: type,
+    value: float,
+    int_type: type,
+    expected_output: str,
+) -> None:
+    """
+    title: Test float -> int cast truncates toward zero.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+      float_type:
+        type: type
+      literal_type:
+        type: type
+      value:
+        type: float
+      int_type:
+        type: type
+      expected_output:
+        type: str
+    """
+    builder = builder_class()
+    module = builder.module()
+
+    decl_a = astx.VariableDeclaration(
+        name="a", type_=float_type(), value=literal_type(value)
+    )
+    cast_var = astx.InlineVariableDeclaration(
+        name="r",
+        type_=int_type(),
+        value=Cast(value=astx.Identifier("a"), target_type=int_type()),
+    )
+    print_stmt = PrintExpr(message=astx.Identifier("r"))
+
+    main_proto = astx.FunctionPrototype(
+        name="main", args=astx.Arguments(), return_type=astx.Int32()
+    )
+    main_block = astx.Block()
+    main_block.append(decl_a)
+    main_block.append(cast_var)
+    main_block.append(print_stmt)
+    main_block.append(astx.FunctionReturn(astx.LiteralInt32(0)))
+    module.block.append(
+        astx.FunctionDef(prototype=main_proto, body=main_block)
+    )
+
+    check_result("build", builder, module, expected_output=expected_output)
+
+
+@pytest.mark.parametrize("builder_class", [LLVMLiteIR])
+def test_cast_same_type_noop(builder_class: Type[Builder]) -> None:
+    """
+    title: Cast a value to its own type should be a no-op.
+    parameters:
+      builder_class:
+        type: Type[Builder]
+    """
+    builder = builder_class()
+    module = builder.module()
+
+    decl_a = astx.VariableDeclaration(
+        name="a", type_=astx.Int32(), value=astx.LiteralInt32(42)
+    )
+    cast_var = astx.InlineVariableDeclaration(
+        name="r",
+        type_=astx.Int32(),
+        value=Cast(value=astx.Identifier("a"), target_type=astx.Int32()),
+    )
+    print_stmt = PrintExpr(message=astx.Identifier("r"))
+
+    main_proto = astx.FunctionPrototype(
+        name="main", args=astx.Arguments(), return_type=astx.Int32()
+    )
+    main_block = astx.Block()
+    main_block.append(decl_a)
+    main_block.append(cast_var)
+    main_block.append(print_stmt)
+    main_block.append(astx.FunctionReturn(astx.LiteralInt32(0)))
+    module.block.append(
+        astx.FunctionDef(prototype=main_proto, body=main_block)
+    )
+
+    check_result("build", builder, module, expected_output="42")


### PR DESCRIPTION
### Notes

- This repository uses an AI bot for reviews. Keep your PR in **Draft** while
  you work. When you’re ready for a review, change the status to **Ready for
  review** to trigger a new review round. If you make additional changes and
  don’t want to trigger the bot, switch the PR back to **Draft**.
- AI-bot comments may not always be accurate. Please review them critically and
  share your feedback; it helps us improve the tool.
- Avoid changing code that is unrelated to your proposal. Keep your PR as short
  as possible to increase the chances of a timely review. Large PRs may not be
  reviewed and may be closed.
- Don’t add unnecessary comments. Your code should be readable and
  self-documenting
  ([guidance](https://google.github.io/styleguide/cppguide.html#Comments)).
- Don’t change core features without prior discussion with the community. Use
  our Discord to discuss ideas, blockers, or issues
  (https://discord.gg/Nu4MdGj9jB).
- Do not include secrets (API keys, tokens, passwords), credentials, or
  sensitive data/PII in code, configs, logs, screenshots, or commit history. If
  something leaks, rotate the credentials immediately, invalidate the old key,
  and note it in the PR so maintainers can assist.
- Do not commit large binaries or generated artifacts. If large datasets are
  needed for tests, prefer small fixtures or programmatic downloads declared in
  makim.yaml (e.g., a task that fetches data at test time). If a large binary is
  unavoidable, discuss first and consider Git LFS.

## Pull Request description

<!-- Describe the purpose of your PR and the changes you have made. -->
This PR rewrites the cast test suite for the `LLVMLiteIR` builder. The previous tests had a fundamental correctness issue: most of them were circular, meaning the expected output was the same as the input regardless of whether the cast actually ran. A test like `int(42) → float → int → exit code 42` would pass even if both casts were no-ops.

- `test_cast_basic` now uses `PrintExpr` to observe the result directly, and includes a genuine truncation case (`300 → i8 = 44`) that would fail if the cast was skipped
- `test_cast_to_string` — consolidates the three separate to-string tests (int, float, boolean) into one parametrized test; `"42.000000"` and `"1"`/`"0"` are outputs that can only appear if the cast ran correctly
- `test_cast_same_type_noop` — covers the early-return path in the builder when source and target types are identical
- `test_cast_float_to_int` — exercises `fptosi` truncation toward zero, including a negative case (`-3.9 → -3`) to distinguish truncation from floor behaviour
- `test_cast_int_to_float` — exercises `sitofp` across `i8`/`i32`/`i64` sources, verified by printing the float (`"7.000000"`)

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solve #4
-->

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->
pytest tests/test_cast.py

- `...`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
