### PR TITLE
feat: support heterogeneous vector-vector numeric unification (closes #270)

### DIFF
--- a/src/irx/builder/core.py
+++ b/src/irx/builder/core.py
@@ -1003,7 +1003,10 @@ class VisitorCore(BuilderVisitor):
         returns:
           type: ir.Value
         """
-        if is_fp_type(lhs.type):
+        check_ty = lhs.type
+        if isinstance(check_ty, ir.VectorType):
+            check_ty = check_ty.element
+        if is_fp_type(check_ty):
             return self._llvm.ir_builder.fcmp_ordered(op_code, lhs, rhs, name)
         if unsigned:
             return self._llvm.ir_builder.icmp_unsigned(
@@ -1158,10 +1161,16 @@ class VisitorCore(BuilderVisitor):
                     f"{lhs.type.count} vs {rhs.type.count}"
                 )
             if lhs.type.element != rhs.type.element:
-                raise Exception(
-                    "Vector element type mismatch: "
-                    f"{lhs.type.element} vs {rhs.type.element}"
+                lhs_elem = lhs.type.element
+                rhs_elem = rhs.type.element
+                count = lhs.type.count
+                common = self._common_numeric_type(
+                    lhs_elem, rhs_elem, unsigned
                 )
+                lhs_vec = ir.VectorType(common, count)
+                rhs_vec = ir.VectorType(common, count)
+                lhs = self._cast_vector_elements(lhs, lhs_vec, unsigned)
+                rhs = self._cast_vector_elements(rhs, rhs_vec, unsigned)
             return lhs, rhs
 
         if lhs_is_vec:
@@ -1220,6 +1229,86 @@ class VisitorCore(BuilderVisitor):
                 rhs = splat_scalar(self._llvm.ir_builder, rhs, vec_ty)
 
         return lhs, rhs
+
+    def _common_numeric_type(
+        self,
+        a: ir.Type,
+        b: ir.Type,
+        unsigned: bool,
+    ) -> ir.Type:
+        """
+        title: >-
+          Return the common promoted numeric type for two scalar LLVM types.
+        parameters:
+          a:
+            type: ir.Type
+          b:
+            type: ir.Type
+          unsigned:
+            type: bool
+        returns:
+          type: ir.Type
+        """
+        a_fp = is_fp_type(a)
+        b_fp = is_fp_type(b)
+        if a_fp and b_fp:
+            a_w = self._float_bit_width(a)
+            b_w = self._float_bit_width(b)
+            return a if a_w >= b_w else b
+        if a_fp and not b_fp:
+            return a
+        if b_fp and not a_fp:
+            return b
+        a_w = getattr(a, "width", 0)
+        b_w = getattr(b, "width", 0)
+        return a if a_w >= b_w else b
+
+    def _cast_vector_elements(
+        self,
+        value: ir.Value,
+        target_vec_type: ir.VectorType,
+        unsigned: bool,
+    ) -> ir.Value:
+        """
+        title: >-
+          Cast a vector value to a target vector type by converting each
+          element.
+        parameters:
+          value:
+            type: ir.Value
+          target_vec_type:
+            type: ir.VectorType
+          unsigned:
+            type: bool
+        returns:
+          type: ir.Value
+        """
+        src_elem = value.type.element
+        dst_elem = target_vec_type.element
+        if src_elem == dst_elem:
+            return value
+        builder = self._llvm.ir_builder
+        if is_fp_type(dst_elem) and is_fp_type(src_elem):
+            if self._float_bit_width(dst_elem) > self._float_bit_width(
+                src_elem
+            ):
+                return builder.fpext(value, target_vec_type)
+            return builder.fptrunc(value, target_vec_type)
+        if is_fp_type(dst_elem) and is_int_type(src_elem):
+            if unsigned:
+                return builder.uitofp(value, target_vec_type)
+            return builder.sitofp(value, target_vec_type)
+        if is_int_type(dst_elem) and is_int_type(src_elem):
+            src_w = getattr(src_elem, "width", 0)
+            dst_w = getattr(dst_elem, "width", 0)
+            if dst_w > src_w:
+                if unsigned:
+                    return builder.zext(value, target_vec_type)
+                return builder.sext(value, target_vec_type)
+            return builder.trunc(value, target_vec_type)
+        raise Exception(
+            f"Cannot cast vector elements from {src_elem} to {dst_elem}"
+        )
 
     def _select_float_type(self, candidates: list[ir.Type]) -> ir.Type:
         """

--- a/src/irx/builder/lowering/binary_ops.py
+++ b/src/irx/builder/lowering/binary_ops.py
@@ -252,10 +252,10 @@ class BinaryOpVisitorMixin(VisitorMixinBase):
             if llvm_fma_rhs is None:
                 raise Exception("FMA requires a valid third operand")
             if llvm_fma_rhs.type != llvm_lhs.type:
-                raise Exception(
-                    f"FMA operand type mismatch: "
-                    f"{llvm_lhs.type} vs {llvm_fma_rhs.type}"
+                llvm_lhs, llvm_fma_rhs = self._unify_numeric_operands(
+                    llvm_lhs, llvm_fma_rhs
                 )
+                llvm_rhs, _ = self._unify_numeric_operands(llvm_rhs, llvm_lhs)
             prev_fast_math = self._fast_math_enabled
             if set_fast:
                 self.set_fast_math(True)
@@ -560,8 +560,6 @@ class BinaryOpVisitorMixin(VisitorMixinBase):
             type: LtBinOp
         """
         llvm_lhs, llvm_rhs, unsigned = self._load_binary_operands(node)
-        if is_vector(llvm_lhs) and is_vector(llvm_rhs):
-            raise Exception(f"Vector binop {node.op_code} not implemented.")
         result = self._emit_numeric_compare(
             "<",
             llvm_lhs,
@@ -580,8 +578,6 @@ class BinaryOpVisitorMixin(VisitorMixinBase):
             type: GtBinOp
         """
         llvm_lhs, llvm_rhs, unsigned = self._load_binary_operands(node)
-        if is_vector(llvm_lhs) and is_vector(llvm_rhs):
-            raise Exception(f"Vector binop {node.op_code} not implemented.")
         result = self._emit_numeric_compare(
             ">",
             llvm_lhs,
@@ -600,8 +596,6 @@ class BinaryOpVisitorMixin(VisitorMixinBase):
             type: LeBinOp
         """
         llvm_lhs, llvm_rhs, unsigned = self._load_binary_operands(node)
-        if is_vector(llvm_lhs) and is_vector(llvm_rhs):
-            raise Exception(f"Vector binop {node.op_code} not implemented.")
         result = self._emit_numeric_compare(
             "<=",
             llvm_lhs,
@@ -620,8 +614,6 @@ class BinaryOpVisitorMixin(VisitorMixinBase):
             type: GeBinOp
         """
         llvm_lhs, llvm_rhs, unsigned = self._load_binary_operands(node)
-        if is_vector(llvm_lhs) and is_vector(llvm_rhs):
-            raise Exception(f"Vector binop {node.op_code} not implemented.")
         result = self._emit_numeric_compare(
             ">=",
             llvm_lhs,
@@ -640,9 +632,6 @@ class BinaryOpVisitorMixin(VisitorMixinBase):
             type: EqBinOp
         """
         llvm_lhs, llvm_rhs, unsigned = self._load_binary_operands(node)
-
-        if is_vector(llvm_lhs) and is_vector(llvm_rhs):
-            raise Exception(f"Vector binop {node.op_code} not implemented.")
 
         if (
             isinstance(llvm_lhs.type, ir.PointerType)
@@ -670,9 +659,6 @@ class BinaryOpVisitorMixin(VisitorMixinBase):
             type: NeBinOp
         """
         llvm_lhs, llvm_rhs, unsigned = self._load_binary_operands(node)
-
-        if is_vector(llvm_lhs) and is_vector(llvm_rhs):
-            raise Exception(f"Vector binop {node.op_code} not implemented.")
 
         if (
             isinstance(llvm_lhs.type, ir.PointerType)

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -613,43 +613,33 @@ def test_vector_size_mismatch_raises(
         _run_vector_binop("+", v1, v2)
 
 
-def test_vector_element_type_mismatch_raises() -> None:
+def test_vector_element_type_promotion() -> None:
     """
-    title: Mismatched vector element types raise an exception.
+    title: Mismatched vector element types are promoted to the wider type.
     """
     builder = setup_builder()
-    v1 = ir.Constant(ir.VectorType(builder._llvm.INT32_TYPE, VEC2), [1] * VEC2)
-    v2 = ir.Constant(ir.VectorType(builder._llvm.INT64_TYPE, VEC2), [1] * VEC2)
-    with pytest.raises(Exception, match="Vector element type mismatch"):
-        _run_vector_binop("+", v1, v2)
+    i32_ty = builder._llvm.INT32_TYPE
+    i64_ty = builder._llvm.INT64_TYPE
+    v1 = ir.Constant(ir.VectorType(i32_ty, VEC2), [1] * VEC2)
+    v2 = ir.Constant(ir.VectorType(i64_ty, VEC2), [1] * VEC2)
+    result = _run_vector_binop("+", v1, v2)
+    assert isinstance(result.type, ir.VectorType)
+    assert result.type.element == i64_ty
+    assert result.type.count == VEC2
 
 
 @pytest.mark.parametrize(
     "op, match",
     [
         ("%", r"Vector binop .* not implemented"),
-        ("==", r"Vector binop .* not implemented"),
-        ("!=", r"Vector binop .* not implemented"),
-        ("<", r"Vector binop .* not implemented"),
-        ("<=", r"Vector binop .* not implemented"),
-        (">", r"Vector binop .* not implemented"),
-        (">=", r"Vector binop .* not implemented"),
     ],
     ids=[
         "unsupported_%",
-        "cmp_eq",
-        "cmp_ne",
-        "cmp_lt",
-        "cmp_le",
-        "cmp_gt",
-        "cmp_ge",
     ],
 )
 def test_unsupported_vector_op_raises(op: str, match: str) -> None:
     """
-    title: >-
-      Unsupported and unimplemented comparison operators all raise an
-      exception.
+    title: Unsupported vector operators raise an exception.
     parameters:
       op:
         type: str

--- a/tests/test_vector_numeric_unification.py
+++ b/tests/test_vector_numeric_unification.py
@@ -1,0 +1,390 @@
+"""
+title: Tests for heterogeneous vector-vector numeric unification (#270).
+"""
+
+from typing import Any
+
+import astx
+import pytest
+
+from irx.builder import Builder, Visitor
+from llvmlite import ir
+
+VEC4 = 4
+VEC2 = 2
+
+
+def setup_builder() -> Visitor:
+    """
+    title: Return a visitor with a live IRBuilder positioned inside main().
+    returns:
+      type: Visitor
+    """
+    main_builder = Builder()
+    visitor = main_builder.translator
+    func_type = ir.FunctionType(visitor._llvm.INT32_TYPE, [])
+    fn = ir.Function(visitor._llvm.module, func_type, name="main")
+    bb = fn.append_basic_block("entry")
+    visitor._llvm.ir_builder = ir.IRBuilder(bb)
+    return visitor
+
+
+def _make_binop_visitor(
+    lhs_val: ir.Value,
+    rhs_val: ir.Value,
+    fma_rhs: ir.Value | None = None,
+) -> Visitor:
+    """
+    title: >-
+      Return a fresh visitor patched to inject pre-built IR values for the LHS,
+      RHS, and FMA_RHS identifiers.
+    parameters:
+      lhs_val:
+        type: ir.Value
+      rhs_val:
+        type: ir.Value
+      fma_rhs:
+        type: ir.Value | None
+    returns:
+      type: Visitor
+    """
+    builder = setup_builder()
+    original_visit = builder.visit
+
+    def mock_visit(node: Any, *args: Any, **kwargs: Any) -> Any:
+        """
+        title: Mock visit.
+        parameters:
+          node:
+            type: Any
+          args:
+            type: Any
+            variadic: positional
+          kwargs:
+            type: Any
+            variadic: keyword
+        returns:
+          type: Any
+        """
+        if isinstance(node, astx.Identifier):
+            mapping = {"LHS": lhs_val, "RHS": rhs_val, "FMA_RHS": fma_rhs}
+            if node.name in mapping:
+                builder.result_stack.append(mapping[node.name])
+                return
+        return original_visit(node, *args, **kwargs)
+
+    builder.visit = mock_visit  # type: ignore[method-assign]
+    return builder
+
+
+def _run_vector_binop(
+    op_code: str,
+    lhs_val: ir.Value,
+    rhs_val: ir.Value,
+    unsigned: bool | None = None,
+    fma_rhs: ir.Value | None = None,
+) -> ir.Value:
+    """
+    title: Drive a BinaryOp through the visitor and return the result.
+    parameters:
+      op_code:
+        type: str
+      lhs_val:
+        type: ir.Value
+      rhs_val:
+        type: ir.Value
+      unsigned:
+        type: bool | None
+      fma_rhs:
+        type: ir.Value | None
+    returns:
+      type: ir.Value
+    """
+    builder = _make_binop_visitor(lhs_val, rhs_val, fma_rhs)
+    bin_op = astx.BinaryOp(
+        op_code, astx.Identifier("LHS"), astx.Identifier("RHS")
+    )
+    if unsigned is not None:
+        bin_op.unsigned = unsigned  # type: ignore[attr-defined]
+    if fma_rhs is not None:
+        bin_op.fma = True  # type: ignore[attr-defined]
+        bin_op.fma_rhs = astx.Identifier("FMA_RHS")  # type: ignore[attr-defined]
+    builder.visit(bin_op)
+    return builder.result_stack.pop()
+
+
+# ---------------------------------------------------------------------------
+# Gap 1: Vector-vector element-type promotion
+# ---------------------------------------------------------------------------
+
+
+class TestVectorVectorPromotion:
+    """
+    title: Tests for heterogeneous vector-vector element-type promotion.
+    """
+
+    def test_int16_plus_int32_vector(self) -> None:
+        """
+        title: vector<i16> + vector<i32> promotes both to vector<i32>.
+        """
+        builder = setup_builder()
+        v1 = ir.Constant(
+            ir.VectorType(builder._llvm.INT16_TYPE, VEC4), [1] * VEC4
+        )
+        v2 = ir.Constant(
+            ir.VectorType(builder._llvm.INT32_TYPE, VEC4), [2] * VEC4
+        )
+        result = _run_vector_binop("+", v1, v2)
+        assert isinstance(result.type, ir.VectorType)
+        assert result.type.element == builder._llvm.INT32_TYPE
+        assert result.type.count == VEC4
+
+    def test_float_plus_double_vector(self) -> None:
+        """
+        title: vector<float> + vector<double> promotes both to vector<double>.
+        """
+        builder = setup_builder()
+        v1 = ir.Constant(
+            ir.VectorType(builder._llvm.FLOAT_TYPE, VEC4), [1.0] * VEC4
+        )
+        v2 = ir.Constant(
+            ir.VectorType(builder._llvm.DOUBLE_TYPE, VEC4), [2.0] * VEC4
+        )
+        result = _run_vector_binop("+", v1, v2)
+        assert isinstance(result.type, ir.VectorType)
+        assert result.type.element == builder._llvm.DOUBLE_TYPE
+        assert result.type.count == VEC4
+
+    def test_unsigned_int_vector_widening_uses_zext(self) -> None:
+        """
+        title: >-
+          Unsigned vector<i16> + vector<i32> uses zext (not sext) for widening.
+        """
+        builder = setup_builder()
+        v1 = ir.Constant(
+            ir.VectorType(builder._llvm.INT16_TYPE, VEC2), [1] * VEC2
+        )
+        v2 = ir.Constant(
+            ir.VectorType(builder._llvm.INT32_TYPE, VEC2), [2] * VEC2
+        )
+        lhs, _rhs = builder._unify_numeric_operands(v1, v2, unsigned=True)
+        assert lhs.type.element == builder._llvm.INT32_TYPE
+        assert getattr(lhs, "opname", "") == "zext"
+
+    def test_signed_int_vector_widening_uses_sext(self) -> None:
+        """
+        title: Signed vector<i16> + vector<i32> uses sext for widening.
+        """
+        builder = setup_builder()
+        v1 = ir.Constant(
+            ir.VectorType(builder._llvm.INT16_TYPE, VEC2), [1] * VEC2
+        )
+        v2 = ir.Constant(
+            ir.VectorType(builder._llvm.INT32_TYPE, VEC2), [2] * VEC2
+        )
+        lhs, _rhs = builder._unify_numeric_operands(v1, v2, unsigned=False)
+        assert lhs.type.element == builder._llvm.INT32_TYPE
+        assert getattr(lhs, "opname", "") == "sext"
+
+    def test_unsigned_int_to_float_vector_uses_uitofp(self) -> None:
+        """
+        title: >-
+          Unsigned vector<i32> + vector<float> converts int to float via
+          uitofp.
+        """
+        builder = setup_builder()
+        v1 = ir.Constant(
+            ir.VectorType(builder._llvm.INT32_TYPE, VEC4), [1] * VEC4
+        )
+        v2 = ir.Constant(
+            ir.VectorType(builder._llvm.FLOAT_TYPE, VEC4), [2.0] * VEC4
+        )
+        lhs, _rhs = builder._unify_numeric_operands(v1, v2, unsigned=True)
+        assert lhs.type.element == builder._llvm.FLOAT_TYPE
+        assert getattr(lhs, "opname", "") == "uitofp"
+
+    def test_signed_int_to_float_vector_uses_sitofp(self) -> None:
+        """
+        title: >-
+          Signed vector<i32> + vector<float> converts int to float via sitofp.
+        """
+        builder = setup_builder()
+        v1 = ir.Constant(
+            ir.VectorType(builder._llvm.INT32_TYPE, VEC4), [1] * VEC4
+        )
+        v2 = ir.Constant(
+            ir.VectorType(builder._llvm.FLOAT_TYPE, VEC4), [2.0] * VEC4
+        )
+        lhs, _rhs = builder._unify_numeric_operands(v1, v2, unsigned=False)
+        assert lhs.type.element == builder._llvm.FLOAT_TYPE
+        assert getattr(lhs, "opname", "") == "sitofp"
+
+    def test_lane_count_mismatch_still_raises(self) -> None:
+        """
+        title: >-
+          Vectors with different lane counts still raise even when element
+          types differ.
+        """
+        builder = setup_builder()
+        v1 = ir.Constant(
+            ir.VectorType(builder._llvm.INT16_TYPE, VEC4), [1] * VEC4
+        )
+        v2 = ir.Constant(
+            ir.VectorType(builder._llvm.INT32_TYPE, VEC2), [2] * VEC2
+        )
+        with pytest.raises(Exception, match="Vector size mismatch"):
+            builder._unify_numeric_operands(v1, v2)
+
+    def test_same_element_type_returns_unchanged(self) -> None:
+        """
+        title: Vectors with identical element types are returned unchanged.
+        """
+        builder = setup_builder()
+        v1 = ir.Constant(
+            ir.VectorType(builder._llvm.INT32_TYPE, VEC4), [1] * VEC4
+        )
+        v2 = ir.Constant(
+            ir.VectorType(builder._llvm.INT32_TYPE, VEC4), [2] * VEC4
+        )
+        lhs, rhs = builder._unify_numeric_operands(v1, v2)
+        assert lhs is v1
+        assert rhs is v2
+
+
+# ---------------------------------------------------------------------------
+# Gap 2: Vector compare operations
+# ---------------------------------------------------------------------------
+
+
+_VEC_CMP_OPS = ["<", ">", "<=", ">=", "==", "!="]
+
+
+class TestVectorCompare:
+    """
+    title: Tests for vector compare operations via the BinaryOp visitor.
+    """
+
+    @pytest.mark.parametrize("op", _VEC_CMP_OPS, ids=_VEC_CMP_OPS)
+    def test_float_vector_compare(self, op: str) -> None:
+        """
+        title: Float vector compares emit fcmp_ordered.
+        parameters:
+          op:
+            type: str
+        """
+        builder = setup_builder()
+        vec_ty = ir.VectorType(builder._llvm.FLOAT_TYPE, VEC4)
+        v1 = ir.Constant(vec_ty, [1.0] * VEC4)
+        v2 = ir.Constant(vec_ty, [2.0] * VEC4)
+        result = _run_vector_binop(op, v1, v2)
+        assert isinstance(result.type, ir.VectorType)
+        assert result.type.count == VEC4
+        assert "fcmp" in str(result)
+
+    @pytest.mark.parametrize("op", _VEC_CMP_OPS, ids=_VEC_CMP_OPS)
+    def test_int_vector_compare_signed(self, op: str) -> None:
+        """
+        title: Signed int vector compares emit icmp.
+        parameters:
+          op:
+            type: str
+        """
+        builder = setup_builder()
+        vec_ty = ir.VectorType(builder._llvm.INT32_TYPE, VEC4)
+        v1 = ir.Constant(vec_ty, [1] * VEC4)
+        v2 = ir.Constant(vec_ty, [2] * VEC4)
+        result = _run_vector_binop(op, v1, v2)
+        assert isinstance(result.type, ir.VectorType)
+        assert result.type.count == VEC4
+        assert "icmp" in str(result)
+
+    @pytest.mark.parametrize("op", _VEC_CMP_OPS, ids=_VEC_CMP_OPS)
+    def test_int_vector_compare_unsigned(self, op: str) -> None:
+        """
+        title: Unsigned int vector compares emit icmp with unsigned predicates.
+        parameters:
+          op:
+            type: str
+        """
+        builder = setup_builder()
+        vec_ty = ir.VectorType(builder._llvm.INT32_TYPE, VEC4)
+        v1 = ir.Constant(vec_ty, [1] * VEC4)
+        v2 = ir.Constant(vec_ty, [2] * VEC4)
+        result = _run_vector_binop(op, v1, v2, unsigned=True)
+        assert isinstance(result.type, ir.VectorType)
+        assert result.type.count == VEC4
+        assert "icmp" in str(result)
+
+    def test_heterogeneous_vector_compare(self) -> None:
+        """
+        title: >-
+          vector<float> < vector<double> promotes to vector<double> then
+          compares.
+        """
+        builder = setup_builder()
+        v1 = ir.Constant(
+            ir.VectorType(builder._llvm.FLOAT_TYPE, VEC4), [1.0] * VEC4
+        )
+        v2 = ir.Constant(
+            ir.VectorType(builder._llvm.DOUBLE_TYPE, VEC4), [2.0] * VEC4
+        )
+        result = _run_vector_binop("<", v1, v2)
+        assert isinstance(result.type, ir.VectorType)
+        assert result.type.count == VEC4
+        assert "fcmp" in str(result)
+
+    def test_scalar_vector_compare(self) -> None:
+        """
+        title: Scalar < vector promotes and splats the scalar, then compares.
+        """
+        builder = setup_builder()
+        vec_ty = ir.VectorType(builder._llvm.INT32_TYPE, VEC4)
+        v = ir.Constant(vec_ty, [1] * VEC4)
+        s = ir.Constant(builder._llvm.INT32_TYPE, 2)
+        result = _run_vector_binop("<", s, v)
+        assert isinstance(result.type, ir.VectorType)
+        assert result.type.count == VEC4
+        assert "icmp" in str(result)
+
+
+# ---------------------------------------------------------------------------
+# Gap 3: FMA unification
+# ---------------------------------------------------------------------------
+
+
+class TestFMAUnification:
+    """
+    title: Tests for FMA with heterogeneous operand types.
+    """
+
+    def test_fma_float_float_double_unifies(self) -> None:
+        """
+        title: >-
+          FMA with vector<float> * vector<float> + vector<double> promotes all
+          to vector<double>.
+        """
+        builder = setup_builder()
+        vf = ir.Constant(
+            ir.VectorType(builder._llvm.FLOAT_TYPE, VEC4), [1.0] * VEC4
+        )
+        vd = ir.Constant(
+            ir.VectorType(builder._llvm.DOUBLE_TYPE, VEC4), [2.0] * VEC4
+        )
+        result = _run_vector_binop("*", vf, vf, fma_rhs=vd)
+        assert isinstance(result.type, ir.VectorType)
+        assert result.type.element == builder._llvm.DOUBLE_TYPE
+        assert result.type.count == VEC4
+
+    def test_fma_same_type_still_works(self) -> None:
+        """
+        title: >-
+          FMA with matching types still works after replacing the hard error
+          with unification.
+        """
+        builder = setup_builder()
+        vec_ty = ir.VectorType(builder._llvm.FLOAT_TYPE, VEC4)
+        v = ir.Constant(vec_ty, [2.0] * VEC4)
+        result = _run_vector_binop("*", v, v, fma_rhs=v)
+        assert isinstance(result.type, ir.VectorType)
+        assert result.type.element == builder._llvm.FLOAT_TYPE
+        assert result.type.count == VEC4


### PR DESCRIPTION
## Summary

Completes the numeric unification story started in #237 by addressing the
three remaining gaps from issue #270.

Closes #270
Related: #135

---

## What changed

### Gap 1 — Vector-vector element-type promotion (`_unify_numeric_operands`)

Previously, two vectors with the same lane count but different element types
raised a `"Vector element type mismatch"` error. Now both vectors are promoted
to the wider common type using the same logic already used for scalars:

- `vector<i16>` + `vector<i32>` → both promoted to `vector<i32>` (sext/zext)
- `vector<float>` + `vector<double>` → both promoted to `vector<double>` (fpext)
- `vector<i32>` + `vector<float>` → int converted to float (sitofp/uitofp)
- Lane-count mismatches still raise

### Gap 2 — Vector compare operators

Compare operators (`<`, `>`, `<=`, `>=`, `==`, `!=`) were previously
unhandled in the vector ops block and raised `"Vector binop not implemented"`.
Now they emit:
- `fcmp_ordered` for float vectors
- `icmp_unsigned` / `icmp_signed` for integer vectors

### Gap 3 — FMA operand unification

The FMA addend (`fma_rhs`) previously raised on any type mismatch with `lhs`.
It is now unified via `_unify_numeric_operands`, so
`FMA(vec<float>, vec<float>, vec<double>)` promotes all operands to
`vector<double>` before emission.

---

## Tests

- **30 new tests** in `tests/test_vector_numeric_unification.py` covering all
  three gaps (int widening, FP rank, signedness semantics, vector compares,
  FMA unification)
- Updated `tests/test_vector.py` to reflect promotion behavior replacing the
  old hard-error cases
- **355 tests pass** with zero regressions

---

## Screenshots

1. All new tests passing:

<img width="1470" height="627" alt="image" src="https://github.com/user-attachments/assets/54fa7c59-cca4-4ce0-b625-e0003202b1ee" />


2. Full suite — zero regressions:

<img width="1470" height="99" alt="image" src="https://github.com/user-attachments/assets/52fc8b4a-1f63-4fda-99cf-890942557a4e" />


### BEFORE (would raise "Vector element type mismatch")
v1 = vector<i16> x4
v2 = vector<i32> x4
v1 + v2  ← RuntimeError

### AFTER (promotes and computes)
v1 + v2  ← result: vector<i32> x4 




